### PR TITLE
Implement minor tileName cleanup

### DIFF
--- a/src/predicates/TilePredicates.ts
+++ b/src/predicates/TilePredicates.ts
@@ -8,13 +8,8 @@ import AbstractTile from "../world/AbstractTile.js";
 // file for putting different implementations of TilePredicate
 
 export class TileWithinDistancePredicate extends TilePredicate {
-    radius: number;
-    targetType: typeof AbstractTile;
-
-    constructor(radius: number, targetType: typeof AbstractTile) {
+    constructor(public radius: number, public targetType: typeof AbstractTile & { readonly tileName: string }) {
         super();
-        this.radius = radius;
-        this.targetType = targetType;
     }
 
     evaluate(run: Game, position: GridCoordinates): boolean {

--- a/src/world/AbstractTile.ts
+++ b/src/world/AbstractTile.ts
@@ -18,10 +18,10 @@ import TilePredicate from "../predicates/TilePredicate.js";
         this.position = position;
     }
 
-    //overload this with a user-visible name for each specific tile subclass
-    static readonly tileName: string = "If you're seeing this you forgot to overrid the tile name"; 
-
-    abstract getTileName(): string; // should return the subclass's overload of tileName
+    // Should return the subclass's tile name. The tileName should
+    // optimally be taken from a `static readonly tileName: string` property on
+    // the subclass, so it can be used in tile predicates.
+    abstract getTileName(): string;
 
     abstract getImgSrc(): string; // the path to the map texture for this tile type
  }


### PR DESCRIPTION
This replaces the previous dummy `tileName` string in `AbstractPredicate`. This way, the compiler doesn't let you use any subclass of `AbstractPredicate` that doesn't have a `static readonly tileName: string` as a target of a `TileWithinDistancePredicate`, letting the user know they need to fix that class's tile name implementation. Usage remains exactly the same, though.

It's annoying that we still can't require them to add the `tileName` property, but at least this way is safer and doesn't provide a default value if one hasn't been implemented.