### PR TITLE
Explicitly block on preloading images

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1,7 +1,10 @@
 import GameWindow from "./UI/GameWindow.js"
+import { preloadImages } from "./UI/Images.js"
 
 // this is the entrypoint to the program.
 window.onload = function() {
     console.log("Script Loaded");
-    GameWindow.showMainMenu();
+    preloadImages().then(() => {
+        GameWindow.showMainMenu();
+    });
 }

--- a/src/UI/Images.ts
+++ b/src/UI/Images.ts
@@ -1,11 +1,17 @@
 /* All images should be declared here so that they start loading as soon as the application starts
  */
 
-
+let imageQueue: Promise<HTMLImageElement>[] = [];
 
 function makeImage(src: string): HTMLImageElement {
     const img = new Image();
-    img.src = src;
+    const imagePromise = new Promise<HTMLImageElement>((resolve, reject) => {
+        img.onload = () => resolve(img);
+        // Don't break everything if an image can't be loaded
+        img.onerror = () => resolve(img);
+        img.src = src;
+    });
+    imageQueue.push(imagePromise);
     return img;
 }
 
@@ -19,3 +25,7 @@ export const SolarPanelsTexture = makeImage("assets/tiles/solar_panels.png");
 export const MountainTexture = makeImage("assets/tiles/mountain.png");
 export const MiningFacilityTexture = makeImage("assets/tiles/mining_facility.png");
 export const LanderTexture = makeImage("assets/tiles/lander.png");
+
+export function preloadImages(): Promise<HTMLImageElement[]> {
+    return Promise.all(imageQueue);
+}


### PR DESCRIPTION
Make sure that we explicitly wait for all images to be prefetched before rendering the main menu. In some cases, `Image` preloading magic will do this for us, but it's not an invariant.