### PR TITLE
Add stripIndent tagged template for multiline indented quotes

### DIFF
--- a/src/UI/transitionScreen/Quote.ts
+++ b/src/UI/transitionScreen/Quote.ts
@@ -1,4 +1,5 @@
 import Random from "../../util/Random.js";
+import { stripIndent } from "../../util/Text.js";
 
 export default class Quote {
 
@@ -6,24 +7,22 @@ export default class Quote {
         readonly text: string,
         readonly attribution: string
     ) {}
-    
+
     private static QuotesList = [
         new Quote("I am an example quote", "Person McQuoteFace"),
         new Quote("Lorem ipsum dolor sit amet", "Mx. Example"),
-        new Quote(
-            // TODO fix the fact that this has to be unindented like this
-`    Multiline versions are also possible,
-and they can use indentation.
+        new Quote(stripIndent`
+                Multiline versions are also possible,
+            and they can use indentation.
 
-    Line breaks are also supported.`,
-             "Author Goes Here"
+                Line breaks are also supported.`,
+            "Author Goes Here"
         ),
-         new Quote(
-             // TODO fix the fact that this has to be unindented like this
-`This is a multiline that does not
-start with indentation`,
-            "Name McNameFace"
-         )
+        new Quote(stripIndent`
+           This is a multiline that does not
+           start with indentation`,
+           "Name McNameFace"
+        )
     ]
 
     static getRandomQuote(): Quote {

--- a/src/UI/transitionScreen/TransitionScreen.ts
+++ b/src/UI/transitionScreen/TransitionScreen.ts
@@ -17,7 +17,6 @@ export default class TransitionScreen {
             this.loadingBar
         ], ['transition-loading-area']);
         this.quote = Quote.getRandomQuote();
-        console.log(this.quote);
 
         UI.fillHTML(this.html, [
             UI.makeDivContaining([

--- a/src/UI/transitionScreen/TransitionScreen.ts
+++ b/src/UI/transitionScreen/TransitionScreen.ts
@@ -18,9 +18,11 @@ export default class TransitionScreen {
         ], ['transition-loading-area']);
         this.quote = Quote.getRandomQuote();
 
+        // Add in leading quote after leading whitespace
+        let quotedText = indentWithNBS(this.quote.text).replace(/^(\s*)/, "$1“") + "”";
         UI.fillHTML(this.html, [
             UI.makeDivContaining([
-                UI.makePara(`“${indentWithNBS(this.quote.text)}”`),
+                UI.makePara(`${quotedText}`),
                 UI.makePara(`-${this.quote.attribution}`, ['transition-attribution'])
             ], ['transition-quote-panel']),
             this.loadingArea

--- a/src/util/Text.ts
+++ b/src/util/Text.ts
@@ -8,6 +8,19 @@ export function indentWithNBS(str: string):  string {
     return str;
 }
 
+/*
+ * A tagged template literal function for processing indented multiline strings.
+ * This takes a template literal as an argument, called with the following
+ * syntax:
+ *
+ *     let str = stripIndent`
+ *         A multiline template string
+ *         Each line may be indented
+ *             This line will still be indented by four spaces`;
+ *
+ * Regular multiline templates do not remove any indentation. This will process
+ * the template and strip extra indentation from the beginning of each line.
+ */
 export function stripIndent(strings: TemplateStringsArray, ...placeholders: string[]): string {
     // Remove leading/trailing newlines and concatenate arguments, accounting
     // for tabs as indentation

--- a/src/util/Text.ts
+++ b/src/util/Text.ts
@@ -2,8 +2,35 @@
 // so we replace them with non-breaking-space characters
 export function indentWithNBS(str: string):  string {
     const fakeTab = "\u00A0".repeat(4);
-    
+
     str = str.replace(/\t/g, fakeTab);
     str = str.replace(/    /g, fakeTab);
     return str;
+}
+
+export function stripIndent(strings: TemplateStringsArray, ...placeholders: string[]): string {
+    // Remove leading/trailing newlines and concatenate arguments, accounting
+    // for tabs as indentation
+    let str = strings
+        .reduce((acc, s, i) => acc + s + (placeholders[i] || ""))
+        .replace(/\t/, "    ")
+        .replace(/^(?:\r?\n)+|(?:\r?\n)+$/g, "");
+    // Split into lines and find the indentation levels of all nonempty ones
+    const lines = str.split(/\r?\n/);
+    const indentLevels = lines
+        .filter(line => line !== "")
+        .map(line => line.match(/^\s*/)![0].length); // regex can't fail to match
+    // Find the minimum indentation across all nonempty lines
+    let minIndent = 0;
+    if (lines.length > 0) {
+        minIndent = indentLevels.reduce((min, len) => Math.min(min, len));
+    }
+    // Drop the minimum indent size from every line and join them back
+    // together
+    if (minIndent > 0) {
+        const strippedLines = lines.map(str => str.substring(minIndent));
+        return strippedLines.join("\n");
+    } else {
+        return lines.join("\n");
+    }
 }


### PR DESCRIPTION
Adds a `stripIndent` tagged template for sensibly creating multiline indented
quotes without caring about indentation:

```
new Quote(stripIndent`
        Multiline versions are also possible,
    and they can use indentation.

        Line breaks are also supported.`,
    "Author Goes Here"
),
```

The level of the minimal amount of indentation across all lines (not counting
empty lines as 0 indentation) is removed from each line. For example, the line
"and they can use indentation" above would end up with no indentation. It also
strips any leading and trailing newlines; the resulting string above would not
have a leading newline.

Also change the leading quotation mark in Quote rendering to be inserted after
any leading indentation.

Also removes an extraneous `console.log`.