### PR TITLE
Add twemoji and automatically patch emoji for text elements

### DIFF
--- a/bundle.config.js
+++ b/bundle.config.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
+module.exports = {
+  entry: path.resolve(__dirname, './out/App.js'),
+  mode: 'development',
+  output: {
+    path: path.resolve(__dirname, './dist'),
+    filename: 'main.js',
+  },
+  devtool: 'source-map',
+  module:  {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [ "source-map-loader" ],
+        enforce: "pre"
+      }
+    ]
+  },
+  optimization: {
+    minimize: false,
+  },
+  plugins: [
+    new CleanWebpackPlugin({
+      protectWebpackAssets: false,
+      cleanBeforeEveryBuildPatterns: [ "*.html", "*.js" ],
+    }),
+  ],
+};

--- a/ci/scripts/before_deploy/make_dist.sh
+++ b/ci/scripts/before_deploy/make_dist.sh
@@ -14,7 +14,7 @@ if [ "$MINIFY" = true ]; then
   npm run minify
   cp dist/index.html "$target"
 else
-  cp -r out "$target"
+  cp -r dist "$target"
   cp -r stylesheets "$target"
   cp index.html "$target"
 fi

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <div id="rootdiv">
         <p>Loading scripts...</p>
     </div>
-    <script type="module" src="./out/App.js"></script>
+    <script type="module" src="./dist/main.js"></script>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,11 @@
       "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==",
       "dev": true
     },
+    "@types/twemoji": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@types/twemoji/-/twemoji-12.1.0.tgz",
+      "integrity": "sha512-dTHU1ZE83qUlF3oFWrdxKBmOimM+/3o9hzDBszcKjajmNu5G/DjWgQrRNkq+zxeR+zDN030ciAt5qTH+WXBD8A=="
+    },
     "@types/uglify-js": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
@@ -2196,6 +2201,26 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -3546,6 +3571,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^0.1.2"
       }
     },
     "kind-of": {
@@ -5999,6 +6033,22 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
+    "twemoji": {
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-12.1.5.tgz",
+      "integrity": "sha512-B0PBVy5xomwb1M/WZxf/IqPZfnoIYy1skXnlHjMwLwTNfZ9ljh8VgWQktAPcJXu8080WoEh6YwQGPVhDVqvrVQ==",
+      "requires": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "12.1.3",
+        "universalify": "^0.1.2"
+      }
+    },
+    "twemoji-parser": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-12.1.3.tgz",
+      "integrity": "sha512-ND4LZXF4X92/PFrzSgGkq6KPPg8swy/U0yRw1k/+izWRVmq1HYi3khPwV3XIB6FRudgVICAaBhJfW8e8G3HC7Q=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -6051,6 +6101,11 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unix-crypt-td-js": {
       "version": "1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -511,6 +511,15 @@
       "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -5547,6 +5556,16 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "source-map-loader": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+      "dev": true,
+      "requires": {
+        "async": "^2.5.0",
+        "loader-utils": "^1.1.0"
+      }
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   },
   "homepage": "https://github.com/GRarer/Aurora#readme",
   "dependencies": {
-    "live-server": "^1.2.1"
+    "@types/twemoji": "^12.1.0",
+    "live-server": "^1.2.1",
+    "twemoji": "^12.1.5",
+    "twemoji-parser": "^12.1.3"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   "main": "out/App.js",
   "scripts": {
     "clean": "rm -r out || true",
-    "build": "npm run clean && npx tsc && echo Build completed",
+    "compile": "npx tsc",
+    "bundle": "npx webpack --config bundle.config.js",
+    "build": "npm run clean && npm run compile && npm run bundle && echo Build completed",
     "start": "npx live-server",
-    "build-watch": "npx tsc -w",
+    "build-watch": "npx webpack --config bundle.config.js --watch | npx tsc --watch",
     "minify": "npx webpack --config ci/webpack.config.js"
   },
   "homepage": "https://github.com/GRarer/Aurora#readme",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
+    "source-map-loader": "^0.2.4",
     "style-loader": "^1.1.2",
     "typescript": "^3.6.4",
     "webpack": "^4.41.2",

--- a/readme.md
+++ b/readme.md
@@ -13,3 +13,9 @@ You can play the most recent build in your browser at <https://grarer.github.io/
 - After forking and cloning the repository, navigate to the `Aurora` directory with your preferred terminal and enter `npm install`. This tells node.js to install all of the developer dependencies, including the typescript compiler and the live server that we use for local testing. You only have to do this once.
 - To compile the game, enter `npm run build`
 - To test the game locally, you need to start a local server and then navigate your web browser to `http://localhost:<port#>/index.html`. Enter `npm run start` in your terminal to start live-server, which will default to `http://localhost:8080` but will use a different port if 8080 is unavailable. After starting the live server, you do not need to restart it after each build; it will reload automatically.
+
+# License and Credits
+
+- For emoji rendering, we use [Twemoji](https://github.com/twitter/twemoji) by
+  Twitter (CC-BY 4.0 license).
+- This project is licensed under the MIT license.

--- a/src/UI/UI.ts
+++ b/src/UI/UI.ts
@@ -3,6 +3,9 @@
  *
  * thank you to May Lawver for her UI code from last semester's game "Prototype Inheritance", which provided some helpful examples
  */
+
+// Emoji rendering is done using the twemoji library
+// (https://github.com/twitter/twemoji)
 import twemoji from "twemoji";
 import * as twemojiParser from "twemoji-parser";
 

--- a/src/UI/UI.ts
+++ b/src/UI/UI.ts
@@ -3,8 +3,10 @@
  *
  * thank you to May Lawver for her UI code from last semester's game "Prototype Inheritance", which provided some helpful examples
  */
+import twemoji from "twemoji";
+import * as twemojiParser from "twemoji-parser";
 
-export default class UI{
+export default class UI {
 
     // makes an empty HTML div with the given css classes
     static makeDiv(classes?: string[]) {
@@ -33,13 +35,32 @@ export default class UI{
         return e;
     }
 
-    // creates an HTML paragraph <p>
-    static makePara(str: string, classes?: string[]): HTMLElement {
-        return UI.makeElement('p', str, classes);
+    // Modifies an element in-place to use Twitter emoji and returns it
+    static patchEmoji(el: HTMLElement): HTMLElement {
+        twemoji.parse(el, { folder: 'svg', ext: '.svg' });
+        return el;
     }
+
+    static containsEmoji(str: string): boolean {
+        return twemojiParser.parse(str).length > 0;
+    }
+
+    // creates an HTML paragraph <p>, supporting Twitter emoji
+    static makePara(str: string, classes?: string[]): HTMLElement {
+        const par = UI.makeElement('p', str, classes);
+        if (UI.containsEmoji(str)) {
+            UI.patchEmoji(par);
+        }
+        return par;
+    }
+
     // created an HTML header, e.g. <H1> or <H2>
     static makeHeader(str: string, level: number = 1, classes?: string[]): HTMLElement {
-        return UI.makeElement(`h${level}`, str, classes);
+        const header = UI.makeElement(`h${level}`, str, classes);
+        if (UI.containsEmoji(str)) {
+            UI.patchEmoji(header);
+        }
+        return header;
     }
 
     // creates a button which executes the given callback function when clicked
@@ -48,13 +69,16 @@ export default class UI{
         b.type = 'button';
         b.disabled = disabled;
         b.innerText = text;
-        if(classes) {
+        if (classes) {
             b.classList.add(...classes);
         }
         b.onclick = function (ev: MouseEvent) {
             ev.preventDefault;
             callback.call(this, ev);
         };
+        if (UI.containsEmoji(text)) {
+            UI.patchEmoji(b);
+        }
         return b;
     }
 

--- a/src/types/twemoji-parser.d.ts
+++ b/src/types/twemoji-parser.d.ts
@@ -1,0 +1,15 @@
+declare module "twemoji-parser" {
+    export type EmojiEntity = {
+        type: string;
+        text: string;
+        url: string;
+        indices: number[];
+    };
+    export type ParsingOptions = {
+        buildUrl?: (codepoints: string, assetType: string) => string;
+        assetType?: 'png' | 'svg';
+    };
+    export function parse(text: string, options?: ParsingOptions): EmojiEntity[];
+    export function toCodePoints(unicodeSurrogates: string): string[];
+    export const TypeName: 'emoji';
+}

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -46,3 +46,10 @@ button[disabled]{
 .fill-vertical {
     height: 100%;
 }
+
+img.emoji {
+    height: 1em;
+    width: 1em;
+    margin: 0 .05em 0 .1em;
+    vertical-align: -0.1em;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "module": "ES6",
     "moduleResolution": "node",
+    "sourceMap": true,
     "newLine": "LF"
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "module": "ES6",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "sourceMap": true,
     "newLine": "LF"
   },


### PR DESCRIPTION
Add the [twemoji](https://github.com/twitter/twemoji) library in order to patch emoji into SVGs with a consistent appearance. Introduces basic function in `UI` for interacting with the library, and makes all text elements patch emoji by default if their text contains it.

Since we test the project by locally hosting it, introducing external libraries makes it impossible with our current setup to resolve dependencies in `node_modules`. Therefore, this also modifies the build process to run minimal webpack bundling over the build output; we don't attempt to minify or inline anything, since that would be slow. Since this necessarily dumps output to one output file, source maps are also created during the build process, which webpack inherits. Now, despite the obfuscated build output, the browser can point to line numbers in the Typescript source when errors occur.