### PR TITLE
Add more stylistic linting rules and fix associated errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,6 +107,12 @@ const styleRules = {
     "allowSingleLine": true,
   }],
 
+  // Prefer `{ ... }` over `{...}`
+  "object-curly-spacing": ["warn", "always"],
+
+  // Prefer `[...]` over `[ ... ]`
+  "array-bracket-spacing": ["warn", "never"],
+
   // Always prefer a semicolon
   "semi": "off",
   "@typescript-eslint/semi": ["warn", "always"],
@@ -124,6 +130,16 @@ const styleRules = {
   "@typescript-eslint/quotes": ["warn", "double", {
     "allowTemplateLiterals": true,
     "avoidEscape": true,
+  }],
+
+  // Prefer `// foo` over `//foo`
+  "spaced-comment": ["warn", "always", {
+    "line": {
+      "markers": ["/"],
+    },
+    "block": {
+      "balanced": true,
+    },
   }],
 
   // Prefer `function foo() { ... }` over `function foo () { ... }`

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -7,7 +7,7 @@ import { QuestStage } from "./quests/QuestStage.js";
 import { TutorialQuestUnpackLander } from "./quests/Quests.js";
 import Technology from "./techtree/Technology.js";
 import { ResearchableTechnologies } from "./techtree/TechTree.js";
-import {Arrays} from "./util/Arrays.js";
+import { Arrays } from "./util/Arrays.js";
 
 // Holds the state of one run of the game, including the game world, inventory, and run statistics
 export default class Game {

--- a/src/UI/GameWindow.ts
+++ b/src/UI/GameWindow.ts
@@ -1,4 +1,4 @@
-import { UI} from "./UI.js";
+import { UI } from "./UI.js";
 
 export interface Page {
     // root element containing this page's HTML

--- a/src/UI/menu/CreditsScreen.ts
+++ b/src/UI/menu/CreditsScreen.ts
@@ -1,4 +1,4 @@
-import { UI} from "../UI.js";
+import { UI } from "../UI.js";
 import { GameWindow, Page } from "../GameWindow.js";
 import MainMenu from "./MainMenu.js";
 

--- a/src/UI/menu/MainMenu.ts
+++ b/src/UI/menu/MainMenu.ts
@@ -1,4 +1,4 @@
-import { UI} from "../UI.js";
+import { UI } from "../UI.js";
 import { GameWindow, Page } from "../GameWindow.js";
 import CreditsScreen from "./CreditsScreen.js";
 import { enableCheats } from "../../util/Cheats.js";

--- a/src/UI/productionScreen/ProductionScreen.ts
+++ b/src/UI/productionScreen/ProductionScreen.ts
@@ -1,5 +1,5 @@
 import Game from "../../Game.js";
-import { UI} from "../UI.js";
+import { UI } from "../UI.js";
 import { GameWindow, Page } from "../GameWindow.js";
 import Conversion from "../../resources/Conversion.js";
 import Inventory from "../../resources/Inventory.js";

--- a/src/UI/researchScreen/ResearchScreen.ts
+++ b/src/UI/researchScreen/ResearchScreen.ts
@@ -1,5 +1,5 @@
 import Game from "../../Game.js";
-import { UI} from "../UI.js";
+import { UI } from "../UI.js";
 import Technology from "../../techtree/Technology.js";
 import { GameWindow, Page } from "../GameWindow.js";
 import WorldScreen from "../worldScreen/WorldScreen.js";

--- a/src/UI/transitionScreen/TransitionScreen.ts
+++ b/src/UI/transitionScreen/TransitionScreen.ts
@@ -1,4 +1,4 @@
-import { UI} from "../UI.js";
+import { UI } from "../UI.js";
 import { GameWindow, Page } from "../GameWindow.js";
 import Quote from "./Quote.js";
 import { indentWithNBS } from "../../util/Text.js";

--- a/src/UI/worldScreen/MapUI.ts
+++ b/src/UI/worldScreen/MapUI.ts
@@ -21,7 +21,7 @@ export default class MapUI {
     private viewWidth: number = 12; // width of viewable area in tiles
     private viewHeight: number = 8; // height of viewable area in tiles
 
-    private viewPosition: GridCoordinates = new GridCoordinates(0, 0); //coordinates of the current view area's top-left tile
+    private viewPosition: GridCoordinates = new GridCoordinates(0, 0); // coordinates of the current view area's top-left tile
     private highlightedCoordinates: GridCoordinates | null = null; // coordinates of current selected tile, null if no tile is selected
 
     constructor(parent: WorldScreen, world: World) {

--- a/src/UI/worldScreen/WorldScreen.ts
+++ b/src/UI/worldScreen/WorldScreen.ts
@@ -1,4 +1,4 @@
-import { UI} from "../UI.js";
+import { UI } from "../UI.js";
 import MapUI from "./MapUI.js";
 import TileSidebar from "./TileSidebar.js";
 import GridCoordinates from "../../world/GridCoordinates.js";

--- a/src/world/Tiles/Habitat.ts
+++ b/src/world/Tiles/Habitat.ts
@@ -2,7 +2,7 @@ import Tile from "../Tile.js";
 import GridCoordinates from "../GridCoordinates.js";
 import Species from "../../resources/Species.js";
 import Housing from "../../resources/Housing.js";
-import {HabitatTexture} from "../../UI/Images.js";
+import { HabitatTexture } from "../../UI/Images.js";
 
 export default class Habitat extends Tile {
 


### PR DESCRIPTION
Adds the following linting rules:
- `spaced-comment`: prefer `// foo` over `//foo`
- `array-bracket-spacing`: prefer `[foo]` over `[ foo ]`
- `object-curly-spacing`: prefer `{ foo }` over `{foo}`

Also fixes the corresponding violations that were caught.

These are probably the last of the stylistic linting rules that should be added.