### PR TITLE
Implement drag-and-drop menu on the production screen

### DIFF
--- a/ci/package-lock.json
+++ b/ci/package-lock.json
@@ -77,6 +77,11 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
+    "@types/sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-aWK2oTpbjNmLyexl95L4ttd0kFIvbMIf1JR2YbNhUwIk9Y1cOwfAfyvfxBBmtg1ZDy64gpbgEdFjyqnzjh+3/A=="
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -2654,7 +2659,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2672,11 +2678,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2689,15 +2697,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2800,7 +2811,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2810,6 +2822,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2822,17 +2835,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2849,6 +2865,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2921,7 +2938,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2931,6 +2949,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3006,7 +3025,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3036,6 +3056,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3053,6 +3074,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3091,11 +3113,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -6199,6 +6223,11 @@
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
+    },
+    "sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/ci/package.json
+++ b/ci/package.json
@@ -24,8 +24,10 @@
   },
   "homepage": "https://github.com/GRarer/Aurora#readme",
   "dependencies": {
+    "@types/sortablejs": "^1.10.2",
     "@types/twemoji": "^12.1.0",
     "live-server": "^1.2.1",
+    "sortablejs": "^1.10.2",
     "twemoji": "^12.1.5",
     "twemoji-parser": "^12.1.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,11 @@
       "integrity": "sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ==",
       "dev": true
     },
+    "@types/sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-aWK2oTpbjNmLyexl95L4ttd0kFIvbMIf1JR2YbNhUwIk9Y1cOwfAfyvfxBBmtg1ZDy64gpbgEdFjyqnzjh+3/A=="
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -4526,6 +4531,11 @@
           }
         }
       }
+    },
+    "sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "homepage": "https://github.com/GRarer/Aurora#readme",
   "dependencies": {
+    "@types/sortablejs": "^1.10.2",
     "@types/twemoji": "^12.1.0",
     "live-server": "^1.2.1",
+    "sortablejs": "^1.10.2",
     "twemoji": "^12.1.5",
     "twemoji-parser": "^12.1.3"
   },

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1,6 +1,5 @@
 import World from "./world/World.js";
 import Inventory from "./resources/Inventory.js";
-import Tile from "./world/Tile.js";
 import Conversion from "./resources/Conversion.js";
 import WorldGenerationParameters from "./world/WorldGenerationParameters.js";
 import { QuestStage } from "./quests/QuestStage.js";
@@ -39,11 +38,28 @@ export default class Game {
         return this.prevQuestDescription;
     }
 
-    // returns all available resource conversions in the order in which they will be applied
-    getResourceConversions(): Conversion[] {
-        const allConversions: Conversion[] = Arrays.flatten(this.world.getTiles().map((tile: Tile) => tile.resourceConversions));
+    private getUnorderedConversions(): Conversion[] {
+        return Arrays.flatten(this.world.getTiles().map(tile => tile.resourceConversions));
+    }
+
+    // Returns all available free and costly resource conversions in the order
+    // in which they will be applied, as two separate arrays
+    getResourceConversions(): { free: Conversion[]; costly: Conversion[]; } {
+        const allConversions = this.getUnorderedConversions();
+        const { yes: free, no: costly } = Arrays.partition(allConversions, c => c.isFree());
         // sort by priority number
-        allConversions.sort((a: Conversion, b: Conversion) => (a.priority - b.priority));
+        free.sort((a, b) => a.priority - b.priority);
+        costly.sort((a, b) => a.priority - b.priority);
+        return { free, costly };
+    }
+
+    // Returns all resource conversions in the order in which they will be
+    // applied; i.e., all free conversions first, followed by costly conversions
+    // in decreasing order of priority.
+    getAllResourceConversions(): Conversion[] {
+        const allConversions = this.getUnorderedConversions();
+        // sort by priority number
+        allConversions.sort((a, b) => a.priority - b.priority);
         return allConversions;
     }
 
@@ -80,7 +96,7 @@ export default class Game {
     // this is called at the end of each turn
     completeTurn(): void {
         // calculate resource production
-        this.inventory.applyConversions(this.getResourceConversions());
+        this.inventory.applyConversions(this.getAllResourceConversions());
 
         this.inventory.releaseWorkers();
         this.inventory.doPopulationGrowth();
@@ -90,48 +106,31 @@ export default class Game {
         this.updateQuestState();
     }
 
-    // moves a resource conversion up by 1 in the production order
-    increaseConversionPriority(conversion: Conversion): void {
-        if (conversion.priority == 0) {
-            return; // priority #0 is for the free conversions (conversions with no inputs), which should not be moved to any other priority
+    // Moves a costly conversion to a different point in the order of
+    // priorities.
+    shiftCostlyConversionPriority(fromIndex: number, toIndex: number): void {
+        if (fromIndex === toIndex || fromIndex < 0) {
+            return;
         }
 
-        const conversionsList = this.getResourceConversions();
-        const index = conversionsList.indexOf(conversion);
-
-        if (index == -1) {
-            return; // conversion not found in the current world
-        } else if (index == 0) {
-            return; // already first in line
+        const { costly } = this.getResourceConversions();
+        if (toIndex >= costly.length) {
+            return;
         }
 
-        // swap priority number with the previous conversion
-        const conversionAbove = conversionsList[index - 1];
-
-        if (conversionAbove.priority == 0) {
-            return; // can't move into priority 0 because only conversions with no inputs should be priority 0
+        // The priority of toIndex after shifting intermediate priorities
+        const priority = costly[fromIndex].priority;
+        if (fromIndex < toIndex) {
+            // Shift intermediate priorities down
+            for (let i = fromIndex; i < toIndex; i++) {
+                costly[i].priority = costly[i + 1].priority;
+            }
+        } else {
+            // Shift intermediate priorities up
+            for (let i = fromIndex; i > toIndex; i--) {
+                costly[i].priority = costly[i - 1].priority;
+            }
         }
-        [conversion.priority, conversionAbove.priority] = [conversionAbove.priority, conversion.priority];
-
-    }
-
-    // moves a resource conversion down by 1 in the production order
-    decreaseConversionPriority(conversion: Conversion): void {
-        if (conversion.priority == 0) {
-            return; // priority #0 is for the free conversions (conversions with no inputs), which should not be moved to any other priority
-        }
-
-        const conversionsList = this.getResourceConversions();
-        const index = conversionsList.indexOf(conversion);
-
-        if (index == -1) {
-            return; // conversion not found in the current world
-        } else if (index == (conversionsList.length - 1)) {
-            return; // already first last in line
-        }
-
-        // swap priority number with the next conversion
-        const conversionBelow = conversionsList[index + 1];
-        [conversion.priority, conversionBelow.priority] = [conversionBelow.priority, conversion.priority];
+        costly[toIndex].priority = priority;
     }
 }

--- a/src/util/Arrays.ts
+++ b/src/util/Arrays.ts
@@ -15,4 +15,19 @@ export namespace Arrays {
     export function flatten<T>(arr: T[][]): T[] {
         return arr.reduce((acc, x) => acc.concat(x), []);
     }
+
+    // Given an array, return all elements that do and do not satisfy the
+    // predicate
+    export function partition<T>(arr: T[], pred: (elem: T) => boolean): { yes: T[]; no: T[]; } {
+        const yes = [];
+        const no = [];
+        for (const x of arr) {
+            if (pred(x)) {
+                yes.push(x);
+            } else {
+                no.push(x);
+            }
+        }
+        return { yes, no };
+    }
 }

--- a/stylesheets/productionscreen.css
+++ b/stylesheets/productionscreen.css
@@ -15,9 +15,14 @@
 }
 
 .conversion-description {
+    margin: 0pt; /* remove margin between description and surrounding box */
     font-size: 16pt;
-    width: 50%;
     text-align: left;
+}
+
+.conversion-description-box {
+    width: 50%;
+    border: 2px solid white;
 }
 
 .conversion-description-normal {


### PR DESCRIPTION
Changes the costly conversion priority list on the production screen to be a drag-and-drop menu. Moves the toggling to an adjacent button, rather than clicking the conversion itself.

Also modifies the structure of conversion priorities. Instead of moving priority levels up and down the list of all costly conversions, the primary API for swapping priorities is to shift a costly conversion to a different index.

Finally, this also cleans up the `this.run.getResourceConversions()` to separate the free from the costly conversions. The old behavior, which returned a list containing all free conversions followed by all costly conversions in order of decreasing priority, has been moved to `getAllResourceConversions()`.