### PR TITLE
Add more ESLint style rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,11 @@ const possibleErrorRules = {
     "checkArrayPredicates": true,
   }],
 
+  // Prefer things like `x || y` over `x ? x : y` or `!x` over `x ? false : true`
+  "no-unneeded-ternary": ["error", {
+    "defaultAssignment": false,
+  }],
+
   // Disallow calling methods without the original class scope
   "@typescript-eslint/unbound-method": ["error", {
     "ignoreStatic": true,
@@ -45,6 +50,17 @@ const possibleErrorRules = {
 
   // Prefer arrow lambdas over aliasing `this`
   "@typescript-eslint/no-this-alias": "error",
+
+  // Prefer `const`
+  "prefer-const": ["warn", {
+    "destructuring": "all",
+  }],
+
+  // Don't use `var`
+  "no-var": "error",
+
+  // Disallow fallthrough in switches
+  "no-fallthrough": "error",
 
   // Prefer `for..of` loops when index is not being used
   "@typescript-eslint/prefer-for-of": "warn",
@@ -91,6 +107,9 @@ const possibleErrorRules = {
 
   // Enforce that optional or default parameters come last
   "@typescript-eslint/default-param-last": "error",
+
+  // Disallow comparing to NaN, prefer `Number.isNaN()`
+  "use-isnan": "error",
 };
 
 // Rules that enforce consistent code style
@@ -110,6 +129,9 @@ const styleRules = {
   // Prefer `{ ... }` over `{...}`
   "object-curly-spacing": ["warn", "always"],
 
+  // Prefer `{ ... }` over `{...}` for blocks
+  "block-spacing": ["warn", "always"],
+
   // Prefer `[...]` over `[ ... ]`
   "array-bracket-spacing": ["warn", "never"],
 
@@ -120,6 +142,9 @@ const styleRules = {
   // Disallow redundant semicolons
   "no-extra-semi": "off",
   "@typescript-eslint/no-extra-semi": "warn",
+
+  // Disallow space before semicolon
+  "semi-spacing": "warn",
 
   // Enforce consistent spacing around commas
   "comma-spacing": "off",
@@ -158,6 +183,9 @@ const styleRules = {
   "func-call-spacing": "off",
   "@typescript-eslint/func-call-spacing": "warn",
 
+  // Prefer `(...) {` over `(...){`
+  "space-before-blocks": ["warn", "always"],
+
   // Prefer `let x: string` over `let x:string`
   "@typescript-eslint/type-annotation-spacing": "warn",
 
@@ -192,6 +220,9 @@ const styleRules = {
   // Prefer Array.prototype.includes over Array.prototype.indexOf for
   // inclusion checks
   "@typescript-eslint/prefer-includes": "warn",
+
+  // Prefer object spreads to `Object.assign()`
+  "prefer-object-spread": "warn",
 };
 
 const disabledRules = {

--- a/src/UI/Images.ts
+++ b/src/UI/Images.ts
@@ -1,7 +1,7 @@
 /* All images should be declared here so that they start loading as soon as the application starts
  */
 
-let imageQueue: Promise<HTMLImageElement>[] = [];
+const imageQueue: Promise<HTMLImageElement>[] = [];
 
 function makeImage(src: string): HTMLImageElement {
     const img = new Image();

--- a/src/UI/menu/CreditsScreen.ts
+++ b/src/UI/menu/CreditsScreen.ts
@@ -4,7 +4,7 @@ import MainMenu from "./MainMenu.js";
 
 
 class CreditsEntry {
-    constructor(public name: string, public roles: string[]){}
+    constructor(public name: string, public roles: string[]) {}
 }
 
 const credits: CreditsEntry[] = [

--- a/src/UI/productionScreen/ProductionScreen.ts
+++ b/src/UI/productionScreen/ProductionScreen.ts
@@ -62,7 +62,7 @@ export default class ProductionScreen implements Page {
             UI.makePara(`Unused workers at end of next production cycle: ${inventoryCopy.getAvailableWorkers()}`, [`production-screen-label`]),
             UI.makePara("Resources available at end of next production cycle:", [`production-screen-label`]),
             this.renderInventory(inventoryCopy),
-            UI.makeButton("Back", () => {GameWindow.show(new WorldScreen(this.run));}, ["production-screen-back-button"]),
+            UI.makeButton("Back", () => { GameWindow.show(new WorldScreen(this.run)); }, ["production-screen-back-button"]),
         ]);
     }
 

--- a/src/UI/transitionScreen/TransitionScreen.ts
+++ b/src/UI/transitionScreen/TransitionScreen.ts
@@ -23,7 +23,7 @@ export default class TransitionScreen implements Page {
         this.quote = Quote.getRandomQuote();
 
         // Add in leading quote after leading whitespace
-        let quotedText = indentWithNBS(this.quote.text).replace(/^(\s*)/, "$1“") + "”";
+        const quotedText = indentWithNBS(this.quote.text).replace(/^(\s*)/, "$1“") + "”";
         UI.fillHTML(this.html, [
             UI.makeDivContaining([
                 UI.makePara(`${quotedText}`),

--- a/src/UI/worldScreen/TileSidebar.ts
+++ b/src/UI/worldScreen/TileSidebar.ts
@@ -75,7 +75,7 @@ export default class TileSidebar implements Page {
 
         const button = UI.makeButton(
             project.title,
-            () => { this.doProject(project, tile);},
+            () => { this.doProject(project, tile); },
             [],
             project.canDo(tile.position, this.run) ? "enabled" : "disabled",
         );

--- a/src/predicates/WorldPredicates.ts
+++ b/src/predicates/WorldPredicates.ts
@@ -8,7 +8,7 @@ export class MinResourcePredicate extends WorldPredicate {
     constructor(
         private resource: Resource,
         private minQuantity: number,
-    ){
+    ) {
         super();
     }
 
@@ -24,7 +24,7 @@ export class MinTilePredicate extends WorldPredicate {
     constructor(
         private tileType: NamedTileType,
         private minQuantity: number,
-    ){
+    ) {
         super();
     }
 

--- a/src/quests/QuestStage.ts
+++ b/src/quests/QuestStage.ts
@@ -5,7 +5,7 @@ export class QuestPath {
     constructor(
         readonly requirement: WorldPredicate,
         readonly nextStage: () => QuestStage,
-    ){}
+    ) {}
 }
 
 export class QuestStage {

--- a/src/resources/Cost.ts
+++ b/src/resources/Cost.ts
@@ -4,7 +4,7 @@ export default class Cost {
     constructor(
         public resource: Resource,
         public quantity: number
-    ){}
+    ) {}
 
     toString(): string {
         return `${this.resource.name} x${this.quantity}`;

--- a/src/resources/Inventory.ts
+++ b/src/resources/Inventory.ts
@@ -14,7 +14,7 @@ export default class Inventory {
 
     constructor(
         private world: World, // used to determine population size limits
-    ){}
+    ) {}
 
     addResource(resource: Resource, quantity: number): void {
         this.resourceQuantities.add(resource, quantity);
@@ -110,7 +110,7 @@ export default class Inventory {
 
     // Attempts to apply each resource conversion in sequence, skipping those for which the inputs are unavailable at that point in the process
     applyConversions(conversions: Conversion[]): void {
-        for (const conversion of conversions){
+        for (const conversion of conversions) {
             if (this.canAfford(conversion.inputs) && this.hasEnoughWorkers(conversion.requiredWorkers) && conversion.enabled) {
                 this.payCost(conversion.inputs);
                 this.occupyWorkers(conversion.requiredWorkers);

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -14,7 +14,7 @@ export default class Resource {
     // the constructor is private because the resources defined as static members above should be the only possible instances
     private constructor(
         public readonly name: string,
-    ){}
+    ) {}
 
     // returns a list of all resource instances
     static values(): Resource[] {

--- a/src/resources/Species.ts
+++ b/src/resources/Species.ts
@@ -7,7 +7,7 @@ export default class Species {
     private constructor(
         public readonly name: string,
         public readonly growthMultiplier: number, // % increase in population per turn
-    ){}
+    ) {}
 
     // returns a list of all species instances
     static values(): Species[] {

--- a/src/techtree/Technology.ts
+++ b/src/techtree/Technology.ts
@@ -8,7 +8,7 @@ export default class Technology {
         public readonly requiredTechs: Technology[],
         public readonly researchCost: Cost,
         public readonly visible: boolean = true,
-    ){}
+    ) {}
 
     static makeUnlockableTechnology(name: string, description: string, requiredTechs: Technology[], researchCost: Cost): Technology {
         const newTech = new Technology(name, description, requiredTechs, researchCost, true);

--- a/src/tileProjects/TileProject.ts
+++ b/src/tileProjects/TileProject.ts
@@ -17,7 +17,7 @@ export default class TileProject {
         readonly costs: Cost[],
         readonly completionRequirements: (TilePredicate | WorldPredicate)[],
         readonly visibilityRequirements: (TilePredicate | WorldPredicate)[]
-    ){}
+    ) {}
 
     canDo(position: GridCoordinates, run: Game): boolean {
         return run.inventory.canAfford(this.costs)

--- a/src/util/Cheats.ts
+++ b/src/util/Cheats.ts
@@ -7,7 +7,7 @@ import { GameWindow } from "../UI/GameWindow.js";
 class Cheats {
     constructor(
         private currentGame: Game,
-    ){}
+    ) {}
 
     // call this to update game and ui after each cheat's effect
     refresh(): void {

--- a/src/util/Quantities.ts
+++ b/src/util/Quantities.ts
@@ -8,7 +8,7 @@
 export default class Quantities<T> {
     private map: Map<T, number> = new Map<T, number>([]);
 
-    constructor(){}
+    constructor() {}
 
     add(key: T, quantity: number): void {
         this.set(key, this.get(key) + quantity);

--- a/src/util/Text.ts
+++ b/src/util/Text.ts
@@ -24,7 +24,7 @@ export function indentWithNBS(str: string):  string {
 export function stripIndent(strings: TemplateStringsArray, ...placeholders: string[]): string {
     // Remove leading/trailing newlines and concatenate arguments, accounting
     // for tabs as indentation
-    let str = strings
+    const str = strings
         .reduce((acc, s, i) => acc + s + (placeholders[i] || ""))
         .replace(/\t/, "    ")
         .replace(/^(?:\r?\n)+|(?:\r?\n)+$/g, "");


### PR DESCRIPTION
Adds the following rules:
- `no-unneeded-ternary`: prefer things like `x || y` over `x ? x : y`
- `prefer-const`: prefer `const` over `let` when possible
- `no-fallthrough`: don't allow fallthrough in switch statements
- `use-isnan`: don't allow comparisons to `NaN`
- `block-spacing`: prefer `{ ... }` over `{...}` for functions
- `semi-spacing`: don't allow spaces before semicolons
- `space-before-blocks`: prefer `(...) {` over `(...){`
- `prefer-object-spread`: prefer object spreads over `Object.assign`

Also fixes the corresponding existing violations.