### PR TITLE
Fix incorrect priority conversion menu shifting

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -127,7 +127,7 @@ export default class Game {
             }
         } else {
             // Shift intermediate priorities down
-            for (let i = toIndex; i > fromIndex; i++) {
+            for (let i = toIndex; i < fromIndex; i++) {
                 costly[i].priority = costly[i + 1].priority;
             }
         }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -119,18 +119,18 @@ export default class Game {
         }
 
         // The priority of toIndex after shifting intermediate priorities
-        const priority = costly[fromIndex].priority;
+        const priority = costly[toIndex].priority;
         if (fromIndex < toIndex) {
-            // Shift intermediate priorities down
-            for (let i = fromIndex; i < toIndex; i++) {
-                costly[i].priority = costly[i + 1].priority;
-            }
-        } else {
             // Shift intermediate priorities up
-            for (let i = fromIndex; i > toIndex; i--) {
+            for (let i = toIndex; i > fromIndex; i--) {
                 costly[i].priority = costly[i - 1].priority;
             }
+        } else {
+            // Shift intermediate priorities down
+            for (let i = toIndex; i > fromIndex; i++) {
+                costly[i].priority = costly[i + 1].priority;
+            }
         }
-        costly[toIndex].priority = priority;
+        costly[fromIndex].priority = priority;
     }
 }


### PR DESCRIPTION
When dragging a constly conversion from one spot to another, the
priorities should be shifted in the opposite direction as the items in
the list; the dragged element should receive the priority of the target
index, not the other way around.

Resolves GRarer/Aurora#40.