### PR TITLE
Even more linting and fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -150,6 +150,9 @@ const styleRules = {
   "comma-spacing": "off",
   "@typescript-eslint/comma-spacing": "warn",
 
+  // Prefer `foo + bar` over `foo+bar`
+  "space-infix-ops": "warn",
+
   // Prefer double-quoted strings
   "quotes": "off",
   "@typescript-eslint/quotes": ["warn", "double", {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,6 +120,9 @@ const styleRules = {
     "ignoredNodes": ["TemplateLiteral > *"],
   }],
 
+  // Disallow trailing whitespace
+  "no-trailing-spaces": "warn",
+
   // Prefer the one true brace style
   "brace-style": "off",
   "@typescript-eslint/brace-style": ["warn", "1tbs", {
@@ -149,6 +152,9 @@ const styleRules = {
   // Enforce consistent spacing around commas
   "comma-spacing": "off",
   "@typescript-eslint/comma-spacing": "warn",
+
+  // Prefer commas on the end of lines
+  "comma-style": "warn",
 
   // Prefer `foo + bar` over `foo+bar`
   "space-infix-ops": "warn",

--- a/src/UI/worldScreen/MapUI.ts
+++ b/src/UI/worldScreen/MapUI.ts
@@ -53,7 +53,7 @@ export default class MapUI implements Page {
         const x = coordinates.x - this.viewPosition.x;
         const y = coordinates.y - this.viewPosition.y;
 
-        if ((x < 0) || (y<0) || (x >= this.viewWidth) || (y >= this.viewHeight)) {
+        if ((x < 0) || (y < 0) || (x >= this.viewWidth) || (y >= this.viewHeight)) {
             return; // don't attempt to draw tiles outside the viewable area
         }
 

--- a/src/UI/worldScreen/WorldScreenHeader.ts
+++ b/src/UI/worldScreen/WorldScreenHeader.ts
@@ -37,7 +37,7 @@ export default class WorldScreenHeader implements Page {
 
         const questHint = this.run.getCurrentQuestHint();
         const questDescription = this.run.getCurrentQuestDescription();
-        const questText = questHint? `${questDescription}\n(hint: ${questHint})` : questDescription;
+        const questText = questHint ? `${questDescription}\n(hint: ${questHint})` : questDescription;
         let questHTML = UI.makePara(`Objective: ${questText}`, ["world-screen-quest-description"]);
 
         // show message after quest completion

--- a/src/world/Tiles/Lander.ts
+++ b/src/world/Tiles/Lander.ts
@@ -24,7 +24,7 @@ export default class Lander extends Tile {
                 world.placeTile(new Habitat(new GridCoordinates(position.x + 1, position.y)));
                 world.placeTile(new MiningFacility(new GridCoordinates(position.x, position.y - 1)));
                 world.placeTile(new SolarPanels(new GridCoordinates(position.x + 1, position.y - 1)));
-                world.placeTile(new Greenhouse(new GridCoordinates(position.x -1, position.y)));
+                world.placeTile(new Greenhouse(new GridCoordinates(position.x - 1, position.y)));
 
                 // remove pod
                 world.placeTile(new Wasteland(position));


### PR DESCRIPTION
Add the following rules:

* `space-infix-ops`: Prefer `a + b` over `a+b`, etc.
* `comma-style`: Reinforce comma style for multiline comma-separated blocks
* `no-trailing-spaces`: Disallow trailing whitespace

Also fixes the `space-infix-ops`-related violations.