### PR TITLE
Refactor Wasteland random texture selection

### DIFF
--- a/src/UI/transitionScreen/Quote.ts
+++ b/src/UI/transitionScreen/Quote.ts
@@ -1,5 +1,6 @@
 import { Random } from "../../util/Random.js";
 import { stripIndent } from "../../util/Text.js";
+import { NonEmptyArray } from "../../util/Arrays.js";
 
 export default class Quote {
 
@@ -8,7 +9,7 @@ export default class Quote {
         readonly attribution: string
     ) {}
 
-    private static readonly QuotesList = [
+    private static readonly QuotesList: NonEmptyArray<Quote> = [
         new Quote("I am an example quote", "Person McQuoteFace"),
         new Quote("Lorem ipsum dolor sit amet", "Mx. Example"),
         new Quote(

--- a/src/util/Arrays.ts
+++ b/src/util/Arrays.ts
@@ -2,6 +2,11 @@
 export type NonEmptyArray<T> = [T, ...T[]];
 
 export namespace Arrays {
+    // Type predicate to assert that a 'T[]' is a 'NonEmptyArray<T>'
+    export function isNonEmpty<T>(arr: T[]): arr is NonEmptyArray<T> {
+        return arr.length > 0;
+    }
+
     // creates a list of the desired length, filling it with values produced by the given function
     export function generate<T>(length: number, func: () => T): T[] {
         const result: T[] = new Array(length);

--- a/src/util/Random.ts
+++ b/src/util/Random.ts
@@ -17,4 +17,21 @@ export namespace Random {
     export function fromArray<T>(arr: T[]): T {
         return arr[intBetween(0, arr.length)];
     }
+
+    // Randomly select an element from an array, with selection biased based on
+    // a weight for each element.
+    export function fromWeightedArray<T>(weightedElems: [number, T][]): T {
+        const totalWeight = weightedElems.map(e => e[0]).reduce((x, y) => x + y, 0);
+        let n = Math.random() * totalWeight;
+        for (const [weight, x] of weightedElems) {
+            if (n <= weight) {
+                return x;
+            } else {
+                n -= weight;
+            }
+        }
+        // Default to the last element in the rare case that something went
+        // wrong with floating point
+        return weightedElems[weightedElems.length - 1][1];
+    }
 }

--- a/src/util/Random.ts
+++ b/src/util/Random.ts
@@ -1,3 +1,5 @@
+import { NonEmptyArray } from "./Arrays.js";
+
 /* random number generation helper methods
  * adapted from Prototype Inheritance by May Lawver
  */
@@ -14,17 +16,17 @@ export namespace Random {
     }
 
     // randomly selected element from an array
-    export function fromArray<T>(arr: T[]): T {
+    export function fromArray<T>(arr: NonEmptyArray<T>): T {
         return arr[intBetween(0, arr.length)];
     }
 
     // Randomly select an element from an array, with selection biased based on
     // a weight for each element.
-    export function fromWeightedArray<T>(weightedElems: [number, T][]): T {
+    export function fromWeightedArray<T>(weightedElems: NonEmptyArray<[number, T]>): T {
         const totalWeight = weightedElems.map(e => e[0]).reduce((x, y) => x + y, 0);
         let n = Math.random() * totalWeight;
         for (const [weight, x] of weightedElems) {
-            if (n <= weight) {
+            if (n < weight) {
                 return x;
             } else {
                 n -= weight;

--- a/src/world/Tiles/Wasteland.ts
+++ b/src/world/Tiles/Wasteland.ts
@@ -14,18 +14,17 @@ import { StructureConstructionTech } from "../../techtree/TechTree.js";
 import Greenhouse from "./Greenhouse.js";
 import { Random } from "../../util/Random.js";
 import { WastelandTexture1, WastelandTexture2, WastelandTexture3, WastelandTexture4, WastelandTexture5 } from "../../UI/Images.js";
-import { Arrays } from "../../util/Arrays.js";
 
 
 
 export default class Wasteland extends Tile {
 
-    texture: HTMLImageElement = Random.fromArray([
-        WastelandTexture1,
-        WastelandTexture2,
-        WastelandTexture3,
-        WastelandTexture4,
-        ...Arrays.repeat(WastelandTexture5, 4)
+    texture: HTMLImageElement = Random.fromWeightedArray([
+        [1 / 8, WastelandTexture1],
+        [1 / 8, WastelandTexture2],
+        [1 / 8, WastelandTexture3],
+        [1 / 8, WastelandTexture4],
+        [4 / 8, WastelandTexture5],
     ]);
 
     constructor(position: GridCoordinates) {

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -32,8 +32,10 @@ export default class World {
         const mountainNumber = Random.intBetween(params.minMountains, params.maxMountains);
         for (let i = 0; i < mountainNumber; i++) {
             const wastelandTiles = this.getTiles().filter((tile: Tile) => (tile instanceof Wasteland));
-            const position = Random.fromArray(wastelandTiles).position;
-            this.placeTile(new Mountain(position));
+            if (Arrays.isNonEmpty(wastelandTiles)) {
+                const position = Random.fromArray(wastelandTiles).position;
+                this.placeTile(new Mountain(position));
+            }
         }
 
         // place the tiles specified in the parameters


### PR DESCRIPTION
Uses a new `Random.fromWeightedArray` to do Wasteland random texture selection instead of manually replicating elements to give them a bias.