### PR TITLE
Fix bug with getting list of resource by key

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -25,6 +25,9 @@ export default class Resource {
 
     // returns a list of all resource instances
     static values(): Resource[] {
-        return Object.keys(Resource).map((k: string) => ((Resource as { [key: string]: any;})[k] as Resource));
+        const safeKeys = <T>(x: T): (keyof T)[] => Object.keys(x) as (keyof T)[];
+        return safeKeys(Resource)
+            .map(k => Resource[k])
+            .filter((v): v is Resource => v instanceof Resource);
     }
 }

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,3 +1,5 @@
+import { Objects } from "../util/Objects.js";
+
 export default class Resource {
     // all resource instances are defined here
     static readonly Energy = new Resource("⚡ Energy");
@@ -25,8 +27,7 @@ export default class Resource {
 
     // returns a list of all resource instances
     static values(): Resource[] {
-        const safeKeys = <T>(x: T): (keyof T)[] => Object.keys(x) as (keyof T)[];
-        return safeKeys(Resource)
+        return Objects.safeKeys(Resource)
             .map(k => Resource[k])
             .filter((v): v is Resource => v instanceof Resource);
     }

--- a/src/resources/Species.ts
+++ b/src/resources/Species.ts
@@ -15,6 +15,9 @@ export default class Species {
 
     // returns a list of all species instances
     static values(): Species[] {
-        return Object.keys(Species).map((k: string) => ((Species as { [key: string]: any;})[k] as Species));
+        const safeKeys = <T>(x: T): (keyof T)[] => Object.keys(x) as (keyof T)[];
+        return safeKeys(Species)
+            .map(k => Species[k])
+            .filter((v): v is Species => v instanceof Species);
     }
 }

--- a/src/resources/Species.ts
+++ b/src/resources/Species.ts
@@ -1,5 +1,6 @@
 import Cost from "./Cost";
 import Resource from "./Resource";
+import { Objects } from "../util/Objects.js";
 
 export default class Species {
     // all species instances are defined here
@@ -15,8 +16,7 @@ export default class Species {
 
     // returns a list of all species instances
     static values(): Species[] {
-        const safeKeys = <T>(x: T): (keyof T)[] => Object.keys(x) as (keyof T)[];
-        return safeKeys(Species)
+        return Objects.safeKeys(Species)
             .map(k => Species[k])
             .filter((v): v is Species => v instanceof Species);
     }

--- a/src/util/Objects.ts
+++ b/src/util/Objects.ts
@@ -1,0 +1,5 @@
+export namespace Objects {
+    export function safeKeys<T>(x: T): (keyof T)[] {
+        return Object.keys(x) as (keyof T)[];
+    }
+}


### PR DESCRIPTION
The querying of the list of all `Resource` instances by looking at the keys of `Resource` was not safe, and was liable to break in the context of code transformations. This may be the cause of the bug on GitHub pages in which an extra resource, shown as the empty string, was displayed when using cheats; this likely corresponds to the extra key `values: () => Resource[]` in `typeof Resource`. This improves the typing of that function, and ensures that only instances of `Resource` are returned in the list, rather than unsafely casting.