### PR TITLE
Add newtype functionality

### DIFF
--- a/src/util/Newtypes.ts
+++ b/src/util/Newtypes.ts
@@ -13,7 +13,7 @@
  * 'number'. In order to convert between the two types, you need an isomorphism:
  *
  *   // Make the newtype converter
- *   const Int = newtype<Int>();
+ *   const Int: NewtypeWrapper<Int> = newtype();
  *
  *   // Wrap a 'number' into an 'Int'
  *   const anInt: Int = Int.wrap(3);
@@ -53,10 +53,15 @@ export interface Iso<A, B> {
 }
 
 /**
- * Construct an 'Iso' that is able to convert between a newtype wrapper and its
- * representation type.
+ * A shorthand for the type of the converter returned by 'newtype'.
  */
-export function newtype<N extends Newtype<any, any>>(): Iso<N, NewtypeRepr<N>> {
+export type NewtypeWrapper<N extends Newtype<any, any>> = Iso<N, NewtypeRepr<N>>;
+
+/**
+ * Construct a 'NewtypeWrapper' isomorphism that is able to convert between a
+ * newtype and its representation type.
+ */
+export function newtype<N extends Newtype<any, any>>(): NewtypeWrapper<N> {
     return {
         // Since the wrapper type only carries type information, unsafe coercing
         // is fine here

--- a/src/util/Newtypes.ts
+++ b/src/util/Newtypes.ts
@@ -70,3 +70,19 @@ export function newtype<N extends Newtype<any, any>>(): NewtypeWrapper<N> {
     };
 }
 
+/**
+ * Lift a function on a representation type to a function on a newtype that
+ * wraps it.
+ */
+export function liftN<N extends Newtype<any, any>>(f: (x: NewtypeRepr<N>) => NewtypeRepr<N>): (x: N) => N {
+    return f as unknown as (x: N) => N;
+}
+
+/**
+ * Lift a function of two arguments on a representation type to a function on a
+ * newtype that wraps it.
+ */
+export function liftN2<N extends Newtype<any, any>>(f: (x: NewtypeRepr<N>, y: NewtypeRepr<N>) => NewtypeRepr<N>): (x: N, y: N) => N {
+    return f as unknown as (x: N, y: N) => N;
+}
+

--- a/src/util/Newtypes.ts
+++ b/src/util/Newtypes.ts
@@ -1,0 +1,67 @@
+/**
+ * A 'type A = Newtype<N, T>' is like a type synonym 'type A = T', but it
+ * creates a distinct type 'A' with the same runtime representation as 'T'. That
+ * is, it is a compile error to use a value of type 'A' in place of a value of
+ * type 'T' and vice-versa, but the type has no boxing overhead, as it only
+ * exists at compile-time.
+ *
+ * In order to make a new newtype, declare it as follows:
+ *
+ *   type Int = Newtype<{ readonly Int: unique symbol; }, number>;
+ *
+ * This declares 'Int' as a distinct type with the same representation as
+ * 'number'. In order to convert between the two types, you need an isomorphism:
+ *
+ *   // Make the newtype converter
+ *   const Int = newtype<Int>();
+ *
+ *   // Wrap a 'number' into an 'Int'
+ *   const anInt: Int = Int.wrap(3);
+ *
+ *   // Unwrap an 'Int' into a 'number'
+ *   const aNumber: number = Int.unwrap(anInt);
+ *
+ *   // Error! Type 'number' is not assignable to type 'Int'
+ *   const error: Int = aNumber;
+ *
+ * Using this strategy, the type and the converter can both have the same name.
+ */
+export interface Newtype<N, T> {
+    readonly _newtype: N;
+}
+
+/**
+ * Extract the representation type 'T' from a 'Newtype<N, T>'.
+ */
+export type NewtypeRepr<N extends Newtype<any, any>> = N extends Newtype<any, infer T> ? T : never;
+
+/**
+ * Witnesses an isomorphism between two types; that is, encapsulates a way to
+ * convert back and forth between 'A' and 'B', implying that the types are
+ * isomorphic.
+ *
+ * The morphisms in either direction would normally be called 'to' and 'from',
+ * but given that this is only used for wrapping and unwrapping newtypes, they
+ * are simply called 'unwrap' and 'wrap' here instead.
+ *
+ * This is a kind of functional optic, and is a special case of a lens. For more
+ * information about optics in TypeScript, look into 'monocle-ts'.
+ */
+export interface Iso<A, B> {
+    readonly unwrap: (domain: A) => B;
+    readonly wrap: (codomain: B) => A;
+}
+
+/**
+ * Construct an 'Iso' that is able to convert between a newtype wrapper and its
+ * representation type.
+ */
+export function newtype<N extends Newtype<any, any>>(): Iso<N, NewtypeRepr<N>> {
+    return {
+        // Since the wrapper type only carries type information, unsafe coercing
+        // is fine here
+        unwrap: (x: N) => x as NewtypeRepr<N>,
+        wrap: (x: NewtypeRepr<N>) => x as N,
+    };
+}
+


### PR DESCRIPTION
Adds a way to construct **newtypes**, which are like a type aliases, but they create a distinct type. A newtype also has the same runtime representation as its underlying type; there is no boxing overhead.

Adding newtypes can be a useful tool in refactoring.

To initialize a newtype `USD` that has the same representation as `number`:
```typescript
// The type itself
type USD = Newtype<{ readonly USD: unique symbol; }, number>;

// The newtype converter
const USD = newtype<USD>();
```

Unfortunately, the `{ readonly USD: unique symbol; }` is necessary boilerplate that I haven't figured out how to avoid.

Then, you can convert back and forth:
```typescript
// Convert type into newtype wrapper
const usd: USD = USD.wrap(3);

// Convert newtype into underlying type
const three: number = USD.unwrap(usd);

// Compile-time error! Can't assign 'number' to 'USD'
const anError: USD = three;
```