### PR TITLE
Add newtypes to music code

### DIFF
--- a/src/music/Drums.ts
+++ b/src/music/Drums.ts
@@ -1,5 +1,6 @@
 import { SampleInstrument } from "./Instruments.js";
 import { Samples, SampleNames } from "./Samples.js";
+import { MidiNumber } from "./Notes.js";
 import { impossible } from "../util/Util.js";
 
 export enum Drums {
@@ -20,13 +21,13 @@ export namespace Drumkit {
         switch (drum) {
         case Drums.KICK:
             return kick.scheduleNote(context, {
-                midiNumber: 69,
+                midiNumber: MidiNumber(69),
                 start: start,
                 duration: 1
             });
         case Drums.SNARE:
             return snare.scheduleNote(context, {
-                midiNumber: 69,
+                midiNumber: MidiNumber(69),
                 start: start,
                 duration: 1
             });
@@ -34,7 +35,7 @@ export namespace Drumkit {
             noise.env.decay = 0.05;
             noise.volume = 0.5;
             return noise.scheduleNote(context, {
-                midiNumber: 70,
+                midiNumber: MidiNumber(70),
                 start: start,
                 duration: 0.05
             });
@@ -42,7 +43,7 @@ export namespace Drumkit {
             noise.env.decay = 0.2;
             noise.volume = 0.5;
             return noise.scheduleNote(context, {
-                midiNumber: 70,
+                midiNumber: MidiNumber(70),
                 start: start,
                 duration: 0.2
             });

--- a/src/music/Notes.ts
+++ b/src/music/Notes.ts
@@ -1,12 +1,27 @@
 import { mod } from "../util/Util.js";
+import { Newtype, newtype, unwrap } from "../util/Newtypes.js";
+
+/**
+ * A number representing an absolute note, as defined by MIDI.
+ *
+ * Example: middle C (C4) has a 'MidiNumber' of 60.
+ */
+export type MidiNumber = Newtype<number, { readonly _: unique symbol; }>;
+export const MidiNumber = newtype<MidiNumber>();
+
+/**
+ * The frequency, in Hertz, of an absolute note.
+ *
+ * Example: A4 has a 'Frequency' of 440.
+ */
+export type Frequency = Newtype<number, { readonly _: unique symbol; }>;
+export const Frequency = newtype<Frequency>();
 
 export interface Note {
-
-    midiNumber: number; // the MIDI number of the note
+    midiNumber: MidiNumber; // the MIDI number of the note
     start: number; // starting time in seconds
     duration: number; // duration in seconds
-    endNote?: number; // MIDI number of note to end on. if undefined, this has no effect
-
+    endNote?: MidiNumber; // MIDI number of note to end on. if undefined, this has no effect
 }
 
 export namespace Notes {
@@ -16,24 +31,25 @@ export namespace Notes {
         "F#", "G", "G#", "A", "A#", "B"
     ];
 
-    export function midiNumberToFrequency(midiNumber: number): number {
-        return Math.pow(2, (midiNumber - 69) / 12) * 440;
+    export function midiNumberToFrequency(midiNumber: MidiNumber): Frequency {
+        return Frequency(Math.pow(2, (unwrap(midiNumber) - 69) / 12) * 440);
     }
 
-    export function midiNumberToNoteName(midiNumber: number): string {
-        return `${noteNames[mod(midiNumber, 12)]}${Math.floor(midiNumber / 12) - 1}`;
+    export function midiNumberToNoteName(midiNumber: MidiNumber): string {
+        const num = unwrap(midiNumber);
+        return `${noteNames[mod(num, 12)]}${Math.floor(num / 12) - 1}`;
     }
 
     // Pitchshift the given note up and down using the coefficient.
     // If the coefficient is 1, it returns the frequency of the initial note.
     // Otherwise, it returns [frequency / coefficient, frequency, frequency * coefficient].
     // Since frequency perception is logarithmic, this shifts the frequency up and down by the same amount.
-    export function detuneWithCoeff(midiNumber: number, detuneCoeff: number): number[] {
+    export function detuneWithCoeff(midiNumber: MidiNumber, detuneCoeff: number): Frequency[] {
         if (detuneCoeff === 1) {
             return [midiNumberToFrequency(midiNumber)];
         } else {
-            const freq: number = midiNumberToFrequency(midiNumber);
-            return [freq / detuneCoeff, freq, freq * detuneCoeff];
+            const freq: number = unwrap(midiNumberToFrequency(midiNumber));
+            return [freq / detuneCoeff, freq, freq * detuneCoeff].map(Frequency);
         }
     }
 

--- a/src/music/Rhythm.ts
+++ b/src/music/Rhythm.ts
@@ -41,9 +41,10 @@ export default class Rhythm {
         while (beats >= min) {
             // Beats must be larger than the minimum of divisions, so this cast
             // is safe
-            const current: number = Random.fromArray(Rhythm.divisions.filter(num => num <= beats) as NonEmptyArray<number>);
-            beats -= current;
-            this.subdivision.push(current);
+            const validDivisions = Rhythm.divisions.filter(num => num <= beats) as NonEmptyArray<number>;
+            const currentDivision = Random.fromArray(validDivisions);
+            beats -= currentDivision;
+            this.subdivision.push(currentDivision);
         }
         if (beats > 0) {
             this.subdivision.push(beats);

--- a/src/music/Samples.ts
+++ b/src/music/Samples.ts
@@ -1,3 +1,5 @@
+import { Frequency } from "./Notes.js";
+
 // TODO: do this better
 // This is necessary for decoding sample data, but there has to be a better way to do this.
 const tempAudioContext = new AudioContext();
@@ -5,7 +7,7 @@ const tempAudioContext = new AudioContext();
 export interface SampleData {
     buffer: AudioBuffer;
     shouldLoop: boolean;
-    freq: number; // frequency of sample for pitchshifting reasons
+    freq: Frequency; // frequency of sample for pitchshifting reasons
 }
 
 export enum SampleNames {
@@ -45,14 +47,17 @@ export namespace SampleUtils {
 export const Samples: Record<SampleNames, SampleData> = {
     "white_noise": {
         buffer: SampleUtils.createBufferFromGenerator(44100, () => 2 * Math.random() - 1),
-        shouldLoop: true, freq: 440
+        shouldLoop: true,
+        freq: Frequency(440),
     },
     "snare": {
         buffer: SampleUtils.createBufferFromAudioData(22050, "samples/snare.ogg"),
-        shouldLoop: false, freq: 440
+        shouldLoop: false,
+        freq: Frequency(440),
     },
     "kick": {
         buffer: SampleUtils.createBufferFromAudioData(22050, "samples/kick.ogg"),
-        shouldLoop: false, freq: 440
+        shouldLoop: false,
+        freq: Frequency(440),
     }
 };

--- a/src/music/Scales.ts
+++ b/src/music/Scales.ts
@@ -95,8 +95,19 @@ export namespace Scales {
         return r;
     }
 
+    /**
+     * Get the number of notes that are in a scale. This is the same as counting
+     * the number of set bits in its bit vector representation.
+     */
     export function getNumberOfNotes(scale: Scale): number {
-        return getPitchClass(scale).length;
+        let vec = unwrap(scale);
+        // Treat as a 16-bit number and divide-and-conquer, counting the 1s in
+        // each bit pair, then each pair of pairs, and so on.
+        vec = (vec & 0x555) + ((vec >>> 1) & 0x555);
+        vec = (vec & 0x333) + ((vec >>> 2) & 0x333);
+        vec = (vec & 0xF0F) + ((vec >>> 4) & 0xF0F);
+        vec = (vec & 0x0FF) + ((vec >>> 8) & 0x0FF);
+        return vec;
     }
 
     // Rotate a scale left if amount is positive and right if amount is negative

--- a/src/music/Scales.ts
+++ b/src/music/Scales.ts
@@ -1,7 +1,62 @@
 import { mod } from "../util/Util.js";
 import { Arrays } from "../util/Arrays.js";
+import { Newtype, newtype, unwrap } from "../util/Newtypes.js";
 
-export type Scale = number; // scales are encoded with numbers in Ian Ring's format
+/**
+ * Describe the degrees in a scale, encoded in Ian Ring's format as a 12-bit bit
+ * vector. If the `i`th 1 (from the LSB) is at bit `1 << n`, then the `i`th
+ * degree of the scale is `n` semitones up from the root.
+ *
+ * Example: the major scale is `0b101010110101`
+ */
+export type Scale = Newtype<number, { readonly _: unique symbol; }>;
+export const Scale = newtype<Scale>();
+
+/**
+ * A 'Chord' is a subset of a 'Scale', encoded in the same bit vector
+ * representation.
+ */
+export type Chord = Newtype<number, { readonly _: unique symbol; }>;
+export const Chord = newtype<Chord>();
+
+/**
+ * An index of a note into the traditional 12-tone chromatic scale
+ * relative to C. For example: C = 0, C# = 1, F = 6, and so on. Note that a
+ * 'Pitch' does not indicate an absolute note by itself; you must turn it into a
+ * 'MidiNumber' by assigning it relative to a given octave. These can also be
+ * outside of 0-11; mod by 12 to normalize. Note that a 'Pitch' plus a
+ * 'PitchOffset' is a new Pitch.
+ *
+ * Example: E has a 'Pitch' of 4.
+ */
+export type Pitch = Newtype<number, { readonly _: unique symbol; }>;
+export const Pitch = newtype<Pitch>();
+
+/**
+ * An offset from some pitch, measured in semitones. Used to describe pitches in
+ * a scale relative to the root. A group of 'PitchOffset's is referred to as a
+ * "pitch class".
+ *
+ * Example: E, relative to a D, has a 'PitchOffset' of 2.
+ */
+export type PitchOffset = Newtype<number, { readonly _: unique symbol; }>;
+export const PitchOffset = newtype<PitchOffset>();
+
+/**
+ * Apply a semitone offset to a base pitch to produce a new pitch. The resulting
+ * pitch is not guaranteed to be normalized to the 0-11 range.
+ */
+export function offsetPitch(base: Pitch, offset: PitchOffset): Pitch {
+    return Pitch(unwrap(base) + unwrap(offset));
+}
+
+/**
+ * An index into a list of notes in a scale.
+ *
+ * Example: A G in a C major scale would have a 'Degree' of 4.
+ */
+export type Degree = Newtype<number, { readonly _: unique symbol; }>;
+export const Degree = newtype<Degree>();
 
 export interface ScaleQuery {
     // allowed range for number of imperfections (inclusive)
@@ -9,29 +64,32 @@ export interface ScaleQuery {
     // allowed range for number of hemitones (inclusive)
     hemitones?: [number, number];
     // chord that the scale must contain
-    chord?: Scale;
+    chord?: Chord;
     // allowed range for number of notes in the scale (inclusive)
     notes?: [number, number];
 }
 
 export namespace Scales {
 
-    export function createScaleFromPitchClass(pitches: number[]): Scale {
-        if (!pitches.includes(0)) {
+    export function createScaleFromPitchClass(pitches: PitchOffset[]): Scale {
+        if (!pitches.includes(PitchOffset(0))) {
             throw new Error("scales must have a root");
         }
-        return pitches.map(pitch => 1 << mod(pitch, 12)) // mod by 12 to fit into octave
+        const vec = pitches
+            .map(pitch => 1 << mod(unwrap(pitch), 12)) // mod by 12 to fit into octave
             .filter((val, i, arr) => arr.indexOf(val) === i) // remove duplicates
             .reduce((acc, curr) => acc | curr, 0); // combine into final bit vector
+        return Scale(vec);
     }
 
     // turns a scale into the set of pitches from the root
     // i.e., the scale 2^7 + 2^6 + 2^5 + 2^0 becomes [0, 5, 6, 7]
-    export function getPitchClass(scale: Scale): number[] {
-        const r: number[] = [];
-        for (let i = 0; scale !== 0; scale >>>= 1, i++) {
-            if (scale & 1) {
-                r.push(i);
+    export function getPitchClass(scale: Scale): PitchOffset[] {
+        const r = [];
+        let vec = unwrap(scale);
+        for (let i = 0; vec !== 0; vec >>>= 1, i++) {
+            if (vec & 1) {
+                r.push(PitchOffset(i));
             }
         }
         return r;
@@ -43,16 +101,21 @@ export namespace Scales {
 
     // Rotate a scale left if amount is positive and right if amount is negative
     export function rotateScale(scale: Scale, amount: number = 1): Scale { // courtesy of nprindle
+        const vec = unwrap(scale);
         amount = mod(amount, 12); // ensure we only rotate as much as we need to
-        const value = scale << amount | scale >>> (12 - amount);
-        return value & 0xFFF; // mask to make sure it's still a 12-bit vector
+        const value = vec << amount | vec >>> (12 - amount);
+        return Scale(value & 0xFFF); // mask to make sure it's still a 12-bit vector
+    }
+
+    export function hasRoot(scale: Scale): boolean {
+        return (unwrap(scale) & 1) !== 0;
     }
 
     export function getModes(scale: Scale): Scale[] {
         const r: Scale[] = [];
         let curr: Scale = scale;
         do {
-            if (curr & 1) { // only add proper scales - i.e., ones with roots
+            if (hasRoot(curr)) { // only add proper scales - i.e., ones with roots
                 r.push(curr);
             }
             curr = rotateScale(curr, 1); // advance to the next mode
@@ -62,7 +125,7 @@ export namespace Scales {
 
     export function hasInterval(scale: Scale, semitones: number): boolean {
         semitones = mod(semitones, 12);
-        return (scale & (1 << semitones)) !== 0; // if the semitones-th bit is set, the scale contains a given interval
+        return (unwrap(scale) & (1 << semitones)) !== 0; // if the semitones-th bit is set, the scale contains a given interval
     }
 
     // count the instances of a particular interval in a scale
@@ -83,28 +146,30 @@ export namespace Scales {
     }
 
     export function containsScale(parent: Scale, child: Scale): boolean {
-        return (parent & child) === child;
+        return (unwrap(parent) & unwrap(child)) === unwrap(child);
     }
 
-    export function containsChord(scale: Scale, chord: number[]): boolean {
-        return containsScale(scale, createScaleFromPitchClass(chord));
+    export function containsChord(scale: Scale, chord: Chord): boolean {
+        return (unwrap(scale) & unwrap(chord)) === unwrap(chord);
     }
 
     const scales: Scale[] = Arrays.flatten([
-        getModes(0xab5), // major
-        getModes(0x9ab), // neapolitan minor
-        getModes(0x557), // leading whole-tone inverse
-        getModes(0x9ad), // harmonic minor
-        getModes(0x9b5), // harmonic major
-        getModes(0xaad), // melodic minor
-        getModes(0xa6d), // Jeths' mode
-        getModes(0x9b3), // double harmonic major
+        getModes(Scale(0xab5)), // major
+        getModes(Scale(0x9ab)), // neapolitan minor
+        getModes(Scale(0x557)), // leading whole-tone inverse
+        getModes(Scale(0x9ad)), // harmonic minor
+        getModes(Scale(0x9b5)), // harmonic major
+        getModes(Scale(0xaad)), // melodic minor
+        getModes(Scale(0xa6d)), // Jeths' mode
+        getModes(Scale(0x9b3)), // double harmonic major
     ]);
 
     // TODO: this can be made more efficient by caching modes.
     // see if that's worthwhile.
     export function matchesQuery(scale: Scale, query: ScaleQuery): boolean {
-        const outOfBounds = (val: number, range: [number, number]): boolean => (val < range[0] || val > range[1]);
+        const outOfBounds = (val: number, range: [number, number]): boolean => {
+            return (val < range[0]) || (val > range[1]);
+        };
         if (query.notes && outOfBounds(getNumberOfNotes(scale), query.notes)) {
             return false;
         }
@@ -116,7 +181,7 @@ export namespace Scales {
         }
         // Any scale will contain the scale 0. (This is similar to how the empty set is a subset of any set.)
         // In that case it's sensible / slightly more efficient to skip the check if query.chord is 0.
-        if (query.chord !== undefined && query.chord !== 0 && !containsScale(scale, query.chord)) {
+        if (query.chord !== undefined && unwrap(query.chord) !== 0 && !containsChord(scale, query.chord)) {
             return false;
         }
         return true;
@@ -127,8 +192,10 @@ export namespace Scales {
     }
 
     // index into a pitch class, shifting up/down through octaves (ie, -1 is the last element of the class, but an octave down)
-    export function indexIntoPitchClass(pitches: number[], index: number): number {
-        return pitches[mod(index, pitches.length)] + 12 * Math.floor(index / pitches.length);
+    export function indexIntoPitchClass(pitches: PitchOffset[], index: number): PitchOffset {
+        const baseOffset = pitches[mod(index, pitches.length)];
+        const adjust = 12 * Math.floor(index / pitches.length);
+        return PitchOffset(unwrap(baseOffset) + adjust);
     }
 
 }

--- a/src/util/Newtypes.ts
+++ b/src/util/Newtypes.ts
@@ -1,3 +1,5 @@
+const newtypeSymbol = Symbol();
+
 /**
  * A 'type A = Newtype<N, T>' is like a type synonym 'type A = T', but it
  * creates a distinct type 'A' with the same runtime representation as 'T'. That
@@ -7,74 +9,54 @@
  *
  * In order to make a new newtype, declare it as follows:
  *
- *   type Int = Newtype<{ readonly Int: unique symbol; }, number>;
+ *   type Int = Newtype<number, { readonly _: unique symbol; }>;
  *
  * This declares 'Int' as a distinct type with the same representation as
- * 'number'. In order to convert between the two types, you need an isomorphism:
+ * 'number'. In order to wrap values in this newtype, you need to make a
+ * wrapper:
  *
- *   // Make the newtype converter
- *   const Int: NewtypeWrapper<Int> = newtype();
+ *   // Make the newtype wrapper
+ *   const Int = newtype<Int>();
  *
  *   // Wrap a 'number' into an 'Int'
- *   const anInt: Int = Int.wrap(3);
+ *   const anInt: Int = Int(3);
  *
  *   // Unwrap an 'Int' into a 'number'
- *   const aNumber: number = Int.unwrap(anInt);
+ *   const aNumber: number = unwrap(anInt);
  *
  *   // Error! Type 'number' is not assignable to type 'Int'
  *   const error: Int = aNumber;
  *
- * Using this strategy, the type and the converter can both have the same name.
+ * Using this strategy, the type and the wrapper can both have the same name.
  */
-export interface Newtype<N, T> {
-    readonly _newtype: N;
+export interface Newtype<_T, N> {
+    readonly [newtypeSymbol]: N;
 }
 
 /**
  * Extract the representation type 'T' from a 'Newtype<N, T>'.
  */
-export type NewtypeRepr<N extends Newtype<any, any>> = N extends Newtype<any, infer T> ? T : never;
+export type NewtypeRepr<N extends Newtype<any, any>> = N extends Newtype<infer T, any> ? T : never;
 
 /**
- * Witnesses an isomorphism between two types; that is, encapsulates a way to
- * convert back and forth between 'A' and 'B', implying that the types are
- * isomorphic.
- *
- * The morphisms in either direction would normally be called 'to' and 'from',
- * but given that this is only used for wrapping and unwrapping newtypes, they
- * are simply called 'unwrap' and 'wrap' here instead.
- *
- * This is a kind of functional optic, and is a special case of a lens. For more
- * information about optics in TypeScript, look into 'monocle-ts'.
+ * Returns a function that wraps a value of a representation type in a newtype.
  */
-export interface Iso<A, B> {
-    readonly unwrap: (domain: A) => B;
-    readonly wrap: (codomain: B) => A;
+export function newtype<N extends Newtype<any, any> = never>(): (x: NewtypeRepr<N>) => N {
+    return x => x as N;
 }
 
 /**
- * A shorthand for the type of the converter returned by 'newtype'.
+ * Unwrap a newtype, inferring the appropriate underlying type
  */
-export type NewtypeWrapper<N extends Newtype<any, any>> = Iso<N, NewtypeRepr<N>>;
-
-/**
- * Construct a 'NewtypeWrapper' isomorphism that is able to convert between a
- * newtype and its representation type.
- */
-export function newtype<N extends Newtype<any, any>>(): NewtypeWrapper<N> {
-    return {
-        // Since the wrapper type only carries type information, unsafe coercing
-        // is fine here
-        unwrap: (x: N) => x as NewtypeRepr<N>,
-        wrap: (x: NewtypeRepr<N>) => x as N,
-    };
+export function unwrap<N extends Newtype<any, any>>(x: N): NewtypeRepr<N> {
+    return x as NewtypeRepr<N>;
 }
 
 /**
  * Lift a function on a representation type to a function on a newtype that
  * wraps it.
  */
-export function liftN<N extends Newtype<any, any>>(f: (x: NewtypeRepr<N>) => NewtypeRepr<N>): (x: N) => N {
+export function liftN<N extends Newtype<any, any> = never>(f: (x: NewtypeRepr<N>) => NewtypeRepr<N>): (x: N) => N {
     return f as unknown as (x: N) => N;
 }
 
@@ -82,7 +64,7 @@ export function liftN<N extends Newtype<any, any>>(f: (x: NewtypeRepr<N>) => New
  * Lift a function of two arguments on a representation type to a function on a
  * newtype that wraps it.
  */
-export function liftN2<N extends Newtype<any, any>>(f: (x: NewtypeRepr<N>, y: NewtypeRepr<N>) => NewtypeRepr<N>): (x: N, y: N) => N {
+export function liftN2<N extends Newtype<any, any> = never>(f: (x: NewtypeRepr<N>, y: NewtypeRepr<N>) => NewtypeRepr<N>): (x: N, y: N) => N {
     return f as unknown as (x: N, y: N) => N;
 }
 


### PR DESCRIPTION
Adds the following newtype wrappers over `number` in the music code:

- `MidiNumber`: corresponds to an absolute note
    - Example: middle C (C4) has a `MidiNumber` of 60

- `Frequency`: the frequency (in Hertz) used by WebAudio to play a note
    - Example: A4 has a `Frequency` of 440

- `Pitch`: offset into 12-tone chromatic scale relative to C
    - Example: an E would have a `Pitch` of 4
    - Can also be outside of this range, but can be normalized with mod
    - Does not represent an absolute note by itself; must be converted to a `MidiNumber` by assigning it to be relative to some octave
    - Note that a `Pitch` plus a `PitchOffset` is a new `Pitch`, though not necessarily normalized to 0-11

- `PitchOffset`: offset, in semitones, from a pitch
    - Example: an E relative to a D would have a `PitchOffset` of 2
    - Used to describe the pitches in a scale relative to the root
    - A "pitch class" is a `PitchOffset[]`

- `Degree`: index into the notes of a scale
    - Example: A G in a C major scale would have a `Degree` of 4, for the fifth degree

- `Scale`: 12-bit bit vector with 1's denoting the degrees
    - If the `i`th 1 is at `1 << n`, then the `i`th degree is `n` semitones up from the root
    - Example: the major scale is `0xab5`, or `0b101010110101` (0, 2, 4, 5, 7, 9, 11)

- `Chord`: also a 12-bit bit vector, but specifically for holding chords, which are subsets of scales

Does some minor cleanup, including optimizing `getNumberOfNotes`, which had a particularly inefficient implementation.

Also improves the API of newtypes making it easier to create and unwrap newtype instances, and improves the safety of `newtype` and lifting fuctions.

Resolves #69