### PR TITLE
Make music code async, fix discarded promise

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -4,10 +4,9 @@ import MainMenuUI from "./UI/menu/MainMenu.js";
 import { MusicManager } from "./music/MusicManager.js";
 
 // this is the entrypoint to the program.
-window.onload = function() {
+window.onload = async function() {
     console.log("Script Loaded");
-    preloadImages().then(() => {
-        MusicManager.initialize();
-        GameWindow.show(new MainMenuUI());
-    }, () => {});
+    await preloadImages();
+    MusicManager.initialize();
+    GameWindow.show(new MainMenuUI());
 };

--- a/src/music/Drums.ts
+++ b/src/music/Drums.ts
@@ -1,5 +1,5 @@
 import { SampleInstrument } from "./Instruments.js";
-import { Samples, SampleNames } from "./Samples.js";
+import { Samples } from "./Samples.js";
 import { MidiNumber } from "./Notes.js";
 import { impossible } from "../util/Util.js";
 
@@ -9,40 +9,41 @@ export enum Drums {
 
 export namespace Drumkit {
 
-    // The parameters here aren't important, since decay and volume get overwritten in scheduleHit().
-    const noise: SampleInstrument = new SampleInstrument(Samples[SampleNames.WHITE_NOISE], { attack: 0.01, decay: 0.1 }, 1.5);
+    const closedHiHat: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.white_noise, {
+        attack: 0.01, decay: 0.05
+    }, 0.5);
+
+    const openHiHat: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.white_noise, {
+        attack: 0.01, decay: 0.2
+    }, 0.5);
 
     // TODO: generalize sampling
-    const snare: SampleInstrument = new SampleInstrument(Samples[SampleNames.SNARE], { sustain: 1 }, 1.5);
-    const kick: SampleInstrument = new SampleInstrument(Samples[SampleNames.KICK], { sustain: 1 }, 1.5);
+    const snare: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.snare, { sustain: 1 }, 1.5);
+    const kick: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.kick, { sustain: 1 }, 1.5);
 
     // TODO: make these sound good
-    export function scheduleHit(context: AudioContext, start: number, drum: Drums): AudioNode {
+    export async function scheduleHit(context: AudioContext, start: number, drum: Drums): Promise<AudioNode> {
         switch (drum) {
         case Drums.KICK:
-            return kick.scheduleNote(context, {
+            return (await kick).scheduleNote(context, {
                 midiNumber: MidiNumber(69),
                 start: start,
                 duration: 1
             });
         case Drums.SNARE:
-            return snare.scheduleNote(context, {
+            return (await snare).scheduleNote(context, {
                 midiNumber: MidiNumber(69),
                 start: start,
                 duration: 1
             });
         case Drums.CLOSED_HI_HAT:
-            noise.env.decay = 0.05;
-            noise.volume = 0.5;
-            return noise.scheduleNote(context, {
+            return (await closedHiHat).scheduleNote(context, {
                 midiNumber: MidiNumber(70),
                 start: start,
                 duration: 0.05
             });
         case Drums.OPEN_HI_HAT:
-            noise.env.decay = 0.2;
-            noise.volume = 0.5;
-            return noise.scheduleNote(context, {
+            return (await openHiHat).scheduleNote(context, {
                 midiNumber: MidiNumber(70),
                 start: start,
                 duration: 0.2

--- a/src/music/Drums.ts
+++ b/src/music/Drums.ts
@@ -1,5 +1,5 @@
 import { SampleInstrument } from "./Instruments.js";
-import { Samples } from "./Samples.js";
+import { SampleNames, SampleData } from "./Samples.js";
 import { MidiNumber } from "./Notes.js";
 import { impossible } from "../util/Util.js";
 
@@ -7,43 +7,60 @@ export enum Drums {
     KICK, SNARE, CLOSED_HI_HAT, OPEN_HI_HAT
 }
 
-export namespace Drumkit {
+export class Drumkit {
 
-    const closedHiHat: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.white_noise, {
-        attack: 0.01, decay: 0.05
-    }, 0.5);
+    // Dependency inject the available samples
+    constructor(
+        private readonly samples: Record<SampleNames, Promise<SampleData>>
+    ) {}
 
-    const openHiHat: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.white_noise, {
-        attack: 0.01, decay: 0.2
-    }, 0.5);
+    private readonly closedHiHat: Promise<SampleInstrument> = SampleInstrument.fromSample(
+        this.samples.white_noise,
+        { attack: 0.01, decay: 0.05 },
+        0.5
+    );
 
-    // TODO: generalize sampling
-    const snare: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.snare, { sustain: 1 }, 1.5);
-    const kick: Promise<SampleInstrument> = SampleInstrument.fromSample(Samples.kick, { sustain: 1 }, 1.5);
+    private readonly openHiHat: Promise<SampleInstrument> = SampleInstrument.fromSample(
+        this.samples.white_noise,
+        { attack: 0.01, decay: 0.2 },
+        0.5
+    );
+
+    private readonly snare: Promise<SampleInstrument> = SampleInstrument.fromSample(
+        this.samples.snare,
+        { sustain: 1 },
+        1.5
+    );
+
+    private readonly kick: Promise<SampleInstrument> = SampleInstrument.fromSample(
+        this.samples.kick,
+        { sustain: 1 },
+        1.5
+    );
 
     // TODO: make these sound good
-    export async function scheduleHit(context: AudioContext, start: number, drum: Drums): Promise<AudioNode> {
+    async scheduleHit(context: AudioContext, start: number, drum: Drums): Promise<AudioNode> {
         switch (drum) {
         case Drums.KICK:
-            return (await kick).scheduleNote(context, {
+            return (await this.kick).scheduleNote(context, {
                 midiNumber: MidiNumber(69),
                 start: start,
                 duration: 1
             });
         case Drums.SNARE:
-            return (await snare).scheduleNote(context, {
+            return (await this.snare).scheduleNote(context, {
                 midiNumber: MidiNumber(69),
                 start: start,
                 duration: 1
             });
         case Drums.CLOSED_HI_HAT:
-            return (await closedHiHat).scheduleNote(context, {
+            return (await this.closedHiHat).scheduleNote(context, {
                 midiNumber: MidiNumber(70),
                 start: start,
                 duration: 0.05
             });
         case Drums.OPEN_HI_HAT:
-            return (await openHiHat).scheduleNote(context, {
+            return (await this.openHiHat).scheduleNote(context, {
                 midiNumber: MidiNumber(70),
                 start: start,
                 duration: 0.2

--- a/src/music/Instrument.ts
+++ b/src/music/Instrument.ts
@@ -4,6 +4,6 @@ export default abstract class Instrument {
 
     constructor(public volume: number) {}
 
-    abstract scheduleNote(context: AudioContext, note: Note): AudioNode;
+    abstract async scheduleNote(context: AudioContext, note: Note): Promise<AudioNode>;
 
 }

--- a/src/music/Instruments.ts
+++ b/src/music/Instruments.ts
@@ -30,7 +30,7 @@ export class OscillatorInstrument extends Instrument {
         this._detune = Math.pow(2, n / 1200);
     }
 
-    scheduleNote(context: AudioContext, note: Note): AudioNode {
+    async scheduleNote(context: AudioContext, note: Note): Promise<AudioNode> {
         const freqs = Notes.detuneWithCoeff(note.midiNumber, this._detune);
         // note ending frequencies are either where they started or at the endNote
         const endfreqs = (note.endNote === undefined) ? freqs : Notes.detuneWithCoeff(note.endNote, this._detune);
@@ -61,16 +61,15 @@ export class OscillatorInstrument extends Instrument {
 // An instrument that uses an audio sample, speeding it up or slowing it down to play different notes.
 export class SampleInstrument extends Instrument {
 
-    buffer: SampleData;
-    env: AdsrConfig;
-
-    constructor(buffer: SampleData, env: AdsrConfig, volume: number = 1) {
+    private constructor(public buffer: SampleData, public env: AdsrConfig, volume: number = 1) {
         super(volume);
-        this.buffer = buffer;
-        this.env = env;
     }
 
-    scheduleNote(context: AudioContext, note: Note): AudioNode {
+    static async fromSample(buffer: Promise<SampleData>, env: AdsrConfig, volume: number = 1): Promise<SampleInstrument> {
+        return new SampleInstrument(await buffer, env, volume);
+    }
+
+    async scheduleNote(context: AudioContext, note: Note): Promise<AudioNode> {
         const freq = Notes.midiNumberToFrequency(note.midiNumber);
         const bufferNode = context.createBufferSource();
         bufferNode.buffer = this.buffer.buffer;

--- a/src/music/MusicManager.ts
+++ b/src/music/MusicManager.ts
@@ -8,6 +8,7 @@ import { Drumkit, Drums } from "./Drums.js";
 import { Arrays, NonEmptyArray } from "../util/Arrays.js";
 import { mod, impossible } from "../util/Util.js";
 import { unwrap } from "../util/Newtypes.js";
+import { makeSamples, SampleNames, SampleData } from "./Samples.js";
 
 enum MeasureContents {
     DRUMS, CHORDS
@@ -34,6 +35,10 @@ enum ChordFunction {
 export namespace MusicManager {
 
     export const context: AudioContext = new AudioContext();
+
+    export const samples: Record<SampleNames, Promise<SampleData>> = makeSamples(context);
+
+    export const drumkit: Drumkit = new Drumkit(samples);
 
     export const instruments = {
         arp: new OscillatorInstrument(
@@ -110,7 +115,7 @@ export namespace MusicManager {
     }
 
     async function scheduleDrum(start: number, drum: Drums): Promise<void> {
-        const drumOut: AudioNode = await Drumkit.scheduleHit(context, start, drum);
+        const drumOut: AudioNode = await drumkit.scheduleHit(context, start, drum);
         drumOut.connect(masterGain);
     }
 


### PR DESCRIPTION
Fix the discarded promise from #70. To fix this, most relevant queuing functions are marked `async` all the way up to `MusicManager.initialize`. Some new functions are added to assist with lifting promise awaiting through the construction of an object.

I'd like @MayMoonsley to listen to this to make sure it sounds correct, and to help debug if it doesn't. I did a lot of things here that could potentially mess with the timing, and she's a lot more familiar with that than me.

Also removes `SampleNames`, which adds safety that the compiler can figure out on its own.

Resolves #70