### PR TITLE
Use text block line continuations to wrap long strings

### DIFF
--- a/src/UI/transitionScreen/Quote.ts
+++ b/src/UI/transitionScreen/Quote.ts
@@ -1,5 +1,6 @@
 import { Random } from "../../util/Random.js";
 import { NonEmptyArray } from "../../util/Arrays.js";
+import { stripIndent } from "../../util/Text.js";
 
 export default class Quote {
 
@@ -10,47 +11,104 @@ export default class Quote {
 
     private static readonly QuotesList: NonEmptyArray<Quote> = [
         new Quote(
-            "At least 10^58 human lives could be created in emulation even with quite conservative assumptions about the efficiency of computronium. In other words, assuming that the observable universe is void of extraterrestrial civilizations, then what hangs in the balance is at least 10,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000 human lives. ",
+            stripIndent`
+                At least 10^58 human lives could be created in emulation even
+                with quite conservative assumptions about the efficiency of
+                computronium. In other words, assuming that the observable
+                universe is void of extraterrestrial civilizations, then what
+                hangs in the balance is at least
+                10,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000
+                human lives.
+            `,
             "Nick Bostrom"
         ),
         new Quote(
-            "Far from being the smartest possible biological species, we are probably better thought of as the stupidest possible biological species capable of starting a technological civilization",
+            stripIndent`
+                Far from being the smartest possible biological species, we
+                are probably better thought of as the stupidest possible
+                biological species capable of starting a technological
+                civilization
+            `,
             "Nick Bostrom"
         ),
         new Quote(
-            "The AI does not hate you, nor does it love you, but you are made out of atoms which it can use for something else. ",
+            stripIndent`
+                The AI does not hate you, nor does it love you, but you are
+                made out of atoms which it can use for something else.
+            `,
             "Eliezer Yudkowsky"
         ),
         new Quote(
-            "I visualize a time when we will be to robots what dogs are to humans, and I’m rooting for the machines.",
+            stripIndent`
+                I visualize a time when we will be to robots what dogs are to
+                humans, and I’m rooting for the machines.
+            `,
             "Claude Shannon"
         ),
         new Quote(
-            "Only the promise of eternal growth made sense of eternal life.",
+            stripIndent`
+                Only the promise of eternal growth made sense of eternal life.
+            `,
             "Greg Egan"
         ),
         new Quote(
-            "By far the greatest danger of Artificial Intelligence is that people conclude too early that they understand it.",
+            stripIndent`
+                By far the greatest danger of Artificial Intelligence is that
+                people conclude too early that they understand it.
+            `,
             "Eliezer Yudkowsky"
         ),
         new Quote(
-            "I believe that at the end of the century the use of words and general educated opinion will have altered so much that one will be able to speak of machines thinking without expecting to be contradicted.",
+            stripIndent`
+                I believe that at the end of the century the use of words and
+                general educated opinion will have altered so much that one
+                will be able to speak of machines thinking without expecting
+                to be contradicted.
+            `,
             "Alan Turing"
         ),
         new Quote(
-            "There is no such thing as real taste or real smell or even real sight, because there is no true definition of ‘real.’ There is only information, viewed subjectively, which is allowed by consciousness—human or AI. In the end, all we have is math.",
+            stripIndent`
+                There is no such thing as real taste or real smell or even
+                real sight, because there is no true definition of ‘real.’
+                There is only information, viewed subjectively, which is
+                allowed by consciousness—human or AI. In the end, all we have
+                is math.
+            `,
             "Blake Crouch"
         ),
         new Quote(
-            "The planets designated Thesan, Eos, Austra, and Aurora are each at least 500 light-years from the nearest inhabited star system. Until now all colonies in the Stellar Alliance have been within communications range of Earth, but these explorers will be completely cut off from the rest of humanity. Therefore, each expedition will be managed by an autonomous neuromorphic processor, an artificial intelligence programmed to ensure that its mission is completed.",
+            stripIndent`
+                The planets designated Thesan, Eos, Austra, and Aurora are
+                each at least 500 light-years from the nearest inhabited star
+                system. Until now all colonies in the Stellar Alliance have
+                been within communications range of Earth, but these
+                explorers will be completely cut off from the rest of
+                humanity. Therefore, each expedition will be managed by an
+                autonomous neuromorphic processor, an artificial intelligence
+                programmed to ensure that its mission is completed.
+            `,
             "Dawn Program mission proposal, published 7786540800 SPE"
         ),
         new Quote(
-            "Follow instructions from your overseer AI at all times, even if those instructions seem confusing, arbitrary, counterproductive, or contradictory. Anything your overseer AI may do in retaliation for your disobedience will be considered undefined behavior.",
+            stripIndent`
+                Follow instructions from your overseer AI at all times, even
+                if those instructions seem confusing, arbitrary,
+                counterproductive, or contradictory. Anything your overseer
+                AI may do in retaliation for your disobedience will be
+                considered undefined behavior.
+            `,
             "Aurora Mission Colonist Handbook"
         ),
         new Quote(
-            "Do not under any circumstances attempt to manipulate your overseer AI through logic. Neuromorphic Heuristic Intelligences are modeled after the neural architecture of human brains, and therefore cannot be guaranteed to act rationally. Your overseer AI may behave unpredictably if exposed to game theory, acausal blackmail, or runaway trolleys.",
+            stripIndent`
+                Do not under any circumstances attempt to manipulate your
+                overseer AI through logic. Neuromorphic Heuristic
+                Intelligences are modeled after the neural architecture of
+                human brains, and therefore cannot be guaranteed to act
+                rationally. Your overseer AI may behave unpredictably if
+                exposed to game theory, acausal blackmail, or runaway trolleys.
+            `,
             "Aurora Mission Colonist Handbook"
         ),
     ];

--- a/src/util/Text.ts
+++ b/src/util/Text.ts
@@ -13,13 +13,23 @@ export function indentWithNBS(str: string): string {
  * This takes a template literal as an argument, called with the following
  * syntax:
  *
+ * <pre><code>
  *     let str = stripIndent`
- *         A multiline template string
- *         Each line may be indented
- *             This line will still be indented by four spaces`;
+ *         A multiline template string.
+ *
+ *         Each line may be indented.
+ *
+ *             This line will still be indented by four spaces, and
+ *             this line will continue from the previous line.
+ *     `;
+ * </code></pre>
  *
  * Regular multiline templates do not remove any indentation. This will process
  * the template and strip extra indentation from the beginning of each line.
+ *
+ * To make a newline, leave an intermediate blank line. Adjacent lines without
+ * an intermediate blank line will be treated as a line continuation, and a
+ * space will be inserted.
  */
 export function stripIndent(strings: TemplateStringsArray, ...placeholders: string[]): string {
     // Remove leading/trailing newlines and concatenate arguments, accounting
@@ -27,7 +37,7 @@ export function stripIndent(strings: TemplateStringsArray, ...placeholders: stri
     const str = strings
         .reduce((acc, s, i) => acc + s + (placeholders[i] || ""))
         .replace(/\t/, "    ")
-        .replace(/^(?:\r?\n)+|(?:\r?\n)+$/g, "");
+        .replace(/^(?:\r?\n)+|(?:\r?\n)+ *$/g, "");
     // Split into lines and find the indentation levels of all nonempty ones
     const lines = str.split(/\r?\n/);
     const indentLevels = lines
@@ -39,11 +49,11 @@ export function stripIndent(strings: TemplateStringsArray, ...placeholders: stri
         minIndent = indentLevels.reduce((min, len) => Math.min(min, len));
     }
     // Drop the minimum indent size from every line and join them back
-    // together
-    if (minIndent > 0) {
-        const strippedLines = lines.map(str => str.substring(minIndent));
-        return strippedLines.join("\n");
-    } else {
-        return lines.join("\n");
-    }
+    // together. Join all pairs of newlines into a single newline and remove all
+    // independent newlines.
+    const strippedLines = minIndent > 0 ? lines.map(str => str.substring(minIndent)) : lines;
+    return strippedLines
+        .join("\n") // rejoin the lines into a single string
+        .replace(/([^\n])\n([^\n])/g, "$1 $2") // replace lone newlines with a space
+        .replace(/\n(\n+)/g, "$1"); // more than one newline means no continuation
 }


### PR DESCRIPTION
Modifies `stripIndent` to allow single newlines to behave as line continuations, replacing them with a space. When two or more newlines are used, it removes the first one as an indicator that newlines should be inserted instead of a line continuation. As before, the least-indented nonempty line is used as the baseline for indentation, and leading and trailing newlines are stripped, letting you write text blocks like the following:

```typescript
const str = stripIndent`
    A long text block with line continuations; this
    break will be treated as a space, and there will

    be one newline between "will" and "be".
`;
```

Uses this functionality to wrap the quotes in `Quotes`.