### PR TITLE
Refactor music code for WebKit WebAudio compatiblity

### DIFF
--- a/src/music/MusicManager.ts
+++ b/src/music/MusicManager.ts
@@ -211,10 +211,9 @@ export namespace MusicManager {
     export function initialize(): void {
         masterGain.gain.value = 0.25;
         masterGain.connect(context.destination);
-        queueNextMeasure(context.currentTime).catch((reason: any) => {
-            if (reason) {
-                console.error(reason);
-            }
+        queueNextMeasure(context.currentTime).catch(e => {
+            console.error("Music initialization failed:");
+            console.error(e);
         });
     }
 

--- a/src/music/MusicManager.ts
+++ b/src/music/MusicManager.ts
@@ -34,7 +34,16 @@ enum ChordFunction {
 
 export namespace MusicManager {
 
-    export const context: AudioContext = new AudioContext();
+    // Get an AudioContext, in a browser-compatible way
+    export const context: AudioContext = (() => {
+        const theWindow: any = window;
+        const ctor = theWindow.AudioContext ?? theWindow.webkitAudioContext;
+        if (ctor) {
+            return new ctor();
+        } else {
+            throw new Error("AudioContext is not supported");
+        }
+    })();
 
     export const samples: Record<SampleNames, Promise<SampleData>> = makeSamples(context);
 

--- a/src/music/Samples.ts
+++ b/src/music/Samples.ts
@@ -24,6 +24,14 @@ export namespace SampleUtils {
             headers: new Headers({
                 "Content-Type": "audio/ogg"
             })
+        }).catch(async (e) => {
+            if (e instanceof Response) {
+                throw new Error(await e.text());
+            } else if (e instanceof Error) {
+                throw e;
+            } else {
+                throw new Error('Unknown error when fetching sample: ' + e);
+            }
         });
         const arr = await response.arrayBuffer();
         const tempBuffer = await context.decodeAudioData(arr);

--- a/src/music/Samples.ts
+++ b/src/music/Samples.ts
@@ -1,4 +1,5 @@
 import { Frequency } from "./Notes.js";
+import "../polyfills/AudioBuffer.prototype.copyToChannel.js";
 
 export interface SampleData {
     buffer: AudioBuffer;
@@ -8,18 +9,20 @@ export interface SampleData {
 
 export namespace SampleUtils {
 
-    export function createBufferFromGenerator(length: number, func: (i: number) => number): AudioBuffer {
+    // Length is in units of number of samples
+    export function createBufferFromGenerator(context: AudioContext, length: number, func: (i: number) => number): AudioBuffer {
+        // Number of channels, length, sample rate
+        const buffer = context.createBuffer(1, length, 44100);
         const arr: Float32Array = new Float32Array(length);
         for (let i = 0; i < length; i++) {
             arr[i] = func(i);
         }
-        const buffer = new AudioBuffer({ numberOfChannels: 1, sampleRate: 44100, length: length });
         buffer.copyToChannel(arr, 0);
         return buffer;
     }
 
     export async function createBufferFromAudioData(context: AudioContext, length: number, filename: string): Promise<AudioBuffer> {
-        const buffer = new AudioBuffer({ numberOfChannels: 1, sampleRate: 44100, length: length });
+        const buffer = context.createBuffer(1, length, 44100);
         const response = await fetch(`assets/${filename}`, {
             headers: new Headers({
                 "Content-Type": "audio/ogg"
@@ -30,11 +33,18 @@ export namespace SampleUtils {
             } else if (e instanceof Error) {
                 throw e;
             } else {
-                throw new Error('Unknown error when fetching sample: ' + e);
+                throw new Error(`Unknown error when fetching sample: ${e}`);
             }
         });
         const arr = await response.arrayBuffer();
-        const tempBuffer = await context.decodeAudioData(arr);
+        const tempBuffer: AudioBuffer = await new Promise((resolve, reject) => {
+            // Webkit doesn't support the newer Promise-based syntax for
+            // 'AudioContext.prototype.decodeAudioData', only the callback
+            // syntax. This returns 'void' when the callbacks are provided, but
+            // the compiler doesn't think so, so we cast it to 'void' to
+            // silence errors and linter warnings.
+            context.decodeAudioData(arr, resolve, reject) as unknown as void;
+        });
         buffer.copyToChannel(tempBuffer.getChannelData(0), 0);
         return buffer;
     }
@@ -56,7 +66,7 @@ export type SampleNames = "white_noise" | "snare" | "kick";
 export function makeSamples(context: AudioContext): Record<SampleNames, Promise<SampleData>> {
     return {
         white_noise: SampleUtils.makeSampleData({
-            buffer: Promise.resolve(SampleUtils.createBufferFromGenerator(44100, () => 2 * Math.random() - 1)),
+            buffer: Promise.resolve(SampleUtils.createBufferFromGenerator(context, 44100, () => 2 * Math.random() - 1)),
             shouldLoop: true,
             freq: Frequency(440),
         }),

--- a/src/polyfills/AudioBuffer.prototype.copyToChannel.ts
+++ b/src/polyfills/AudioBuffer.prototype.copyToChannel.ts
@@ -1,0 +1,23 @@
+// It's a polyfill, so we must be checking for the presence of an unbound method
+// that would normally be there
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
+interface AudioBuffer {
+    copyToChannel(source: Float32Array, channelNumber: number, startInChannel?: number): void;
+}
+
+if (!AudioBuffer.prototype.copyToChannel) {
+    Object.defineProperty(AudioBuffer.prototype, "copyToChannel", {
+        enumerable: false,
+        configurable: false,
+        writable: false,
+        value: function(this: AudioBuffer, source: Float32Array, channelNumber: number, startInChannel: number = 0): void {
+            const arr = this.getChannelData(channelNumber);
+            const len = Math.min(arr.length, source.length);
+            for (let i = startInChannel, j = 0; j < len; i++, j++) {
+                arr[i] = source[j];
+            }
+        }
+    });
+}


### PR DESCRIPTION
I found that even recent implementations of WebAudio in WebKit-based browsers could lack the following features that the music code needs:

 - `window.AudioContext`
    - Fall back to `window.webkitAudioContext` if it's not available; throw if neither are available
- `AudioContext.prototype.decodeAudioData`'s callback parameters were not optional
    - Instead, wrap this in a `new Promise`, and pass `resolve`/`reject` as the callbacks
    - The compiler doesn't recognize that this returns `void` when callbacks are provided, so we have to cast the result
- `AudioNode`'s constructor
    - Instead, use `AudioContext.prototype.createBuffer`
- `AudioNode.prototype.copyToChannel`
    - Instead, use `AudioNode.prototype.getChannelData` and copy the data into the resulting `Float32Array` manually

For convenience, `AudioNode.prototype.copyToChannel` was also polyfilled to use the above method.

The way that `fetch` reports errors is a nightmare; the error handling has been improved to marshal the errors in the `Response` into an actual exception.