### PR TITLE
Music menu integration

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1,12 +1,10 @@
 import { GameWindow } from "./UI/GameWindow.js";
 import { preloadImages } from "./UI/Images.js";
 import MainMenuUI from "./UI/menu/MainMenu.js";
-import { MusicManager } from "./music/MusicManager.js";
 
 // this is the entrypoint to the program.
 window.onload = async function() {
     console.log("Script Loaded");
     await preloadImages();
-    MusicManager.initialize();
     GameWindow.show(new MainMenuUI());
 };

--- a/src/UI/UI.ts
+++ b/src/UI/UI.ts
@@ -66,9 +66,14 @@ export namespace UI {
         return header;
     }
 
-    // creates a button which executes the given callback function when clicked
-    export function makeButton(text: string, callback: Function, classes?: string[],
-        buttonEnabled: "enabled" | "disabled" = "enabled"): HTMLButtonElement {
+    // Creates a button which executes the given callback function when clicked.
+    // The callback may reference the button itself, as well as the mouse event.
+    export function makeButton(
+        text: string,
+        callback: (this: GlobalEventHandlers, button: HTMLButtonElement, ev: MouseEvent) => any,
+        classes?: string[],
+        buttonEnabled: "enabled" | "disabled" = "enabled"
+    ): HTMLButtonElement {
         const b: HTMLButtonElement = document.createElement("button");
         b.type = "button";
         if (buttonEnabled === "disabled") {
@@ -78,9 +83,9 @@ export namespace UI {
         if (classes) {
             b.classList.add(...classes);
         }
-        b.onclick = function(ev: MouseEvent) {
+        b.onclick = function(this: GlobalEventHandlers, ev: MouseEvent) {
             ev.preventDefault();
-            callback.call(this, ev);
+            callback.call(this, b, ev);
         };
         if (containsEmoji(text)) {
             patchEmoji(b);

--- a/src/UI/menu/MainMenu.ts
+++ b/src/UI/menu/MainMenu.ts
@@ -5,9 +5,8 @@ import SettingsScreen from "./SettingsScreen.js";
 import { enableCheats } from "../../util/Cheats.js";
 import WorldScreen from "../worldScreen/WorldScreen.js";
 import Game from "../../Game.js";
+import { MusicManager } from "../../music/MusicManager.js";
 
-// this may need to become a real class in the future
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export default class MainMenu implements Page {
 
     readonly html: HTMLElement;
@@ -18,6 +17,22 @@ export default class MainMenu implements Page {
     }
 
     refresh(): void {
+        const musicPlaying = MusicManager.isPlaying();
+        let musicButton;
+        if (!musicPlaying) {
+            musicButton = UI.makeButton("start music", () => {
+                MusicManager.initialize();
+                this.refresh();
+            });
+        } else {
+            musicButton = UI.makeButton("stop music", async (button: HTMLButtonElement) => {
+                button.disabled = true;
+                button.innerText = "stopping...";
+                await MusicManager.stop();
+                this.refresh();
+            });
+        }
+
         UI.fillHTML(this.html, [
             UI.makeHeader("Aurora", 1),
             UI.makeDivContaining([
@@ -28,6 +43,7 @@ export default class MainMenu implements Page {
                 }),
                 UI.makeButton("settings", () => GameWindow.show(new SettingsScreen())),
                 UI.makeButton("credits", () => GameWindow.show(new CreditsScreen())),
+                musicButton,
             ], ["main-menu-options"]),
         ]);
     }

--- a/src/UI/menu/SettingsScreen.ts
+++ b/src/UI/menu/SettingsScreen.ts
@@ -30,14 +30,17 @@ export default class SettingsScreen implements Page {
         };
 
         const sliders: HTMLElement[] = [
-            makeTrackedSlider("Volume", 0, 100, this.options.volume, (value: number) => {
-                this.options.volume = value;
+            makeTrackedSlider("Volume", 0, 100, this.options.volume * 100, (value: number) => {
+                this.options.volume = value / 100;
+                Settings.saveOptions(this.options);
             }, 5),
             makeTrackedSlider("View width", 6, 18, this.options.viewWidth, (value: number) => {
                 this.options.viewWidth = value;
+                Settings.saveOptions(this.options);
             }),
             makeTrackedSlider("View height", 4, 12, this.options.viewHeight, (value: number) => {
                 this.options.viewHeight = value;
+                Settings.saveOptions(this.options);
             }),
         ];
 
@@ -48,6 +51,7 @@ export default class SettingsScreen implements Page {
                 UI.makeDivContaining([
                     UI.makeButton("Restore defaults", () => {
                         this.options = SettingsOptions.defaultOptions();
+                        Settings.saveOptions(this.options);
                         this.refresh();
                     }),
                 ]),

--- a/src/music/MusicManager.ts
+++ b/src/music/MusicManager.ts
@@ -6,7 +6,8 @@ import { Scales, Scale, Chord, Pitch, offsetPitch, Degree, ScaleQuery } from "./
 import Rhythm from "./Rhythm.js";
 import { Drumkit, Drums } from "./Drums.js";
 import { Arrays, NonEmptyArray } from "../util/Arrays.js";
-import { mod, impossible } from "../util/Util.js";
+import { Settings } from "../persistence/Settings.js";
+import { clamp, mod, impossible } from "../util/Util.js";
 import { unwrap } from "@nprindle/minewt";
 import { makeSamples, SampleNames, SampleData } from "./Samples.js";
 
@@ -218,7 +219,7 @@ export namespace MusicManager {
     }
 
     export function initialize(): void {
-        masterGain.gain.value = 0.25;
+        masterGain.gain.value = Settings.currentOptions.volume;
         masterGain.connect(context.destination);
         queueNextMeasure(context.currentTime).catch(e => {
             console.error("Music initialization failed:");
@@ -226,8 +227,11 @@ export namespace MusicManager {
         });
     }
 
+    /**
+     * Sets the music volume, with range [0, 1].
+     */
     export function setVolume(volume: number): void {
-        masterGain.gain.value = volume;
+        masterGain.gain.value = clamp(0, volume, 1);
     }
 
 }

--- a/src/persistence/Settings.ts
+++ b/src/persistence/Settings.ts
@@ -1,5 +1,6 @@
 import { Schemas } from "../serialize/Schema.js";
 import { Storage } from "./Storage.js";
+import { MusicManager } from "../music/MusicManager.js";
 
 /**
  * An instance of 'Settings' a set of configuration options for the game.
@@ -12,8 +13,8 @@ export class SettingsOptions {
         public viewWidth: number = 12,
         // height of viewable area in tiles
         public viewHeight: number = 8,
-        // game volume
-        public volume: number = 0,
+        // game volume, from 0 to 1
+        public volume: number = 0.25,
     ) {}
 
     static defaultOptions(): SettingsOptions {
@@ -50,11 +51,23 @@ export namespace Settings {
     export let currentOptions: SettingsOptions = loadOptions();
 
     /**
+     * Applies any settings to the game that don't automatically update when the
+     * current options are changed. For example, the map dimensions are read
+     * from the current settings when the map is shown, and so don't need to be
+     * set here, but the music only reads the current volume when initializing,
+     * so we need to set it here.
+     */
+    export function applySettings(options: SettingsOptions): void {
+        MusicManager.setVolume(options.volume);
+    }
+
+    /**
      * Saves a set of options to the store, and sets the current set of options
      * to the set provided.
      */
     export function saveOptions(options: SettingsOptions): void {
         currentOptions = options;
+        applySettings(currentOptions);
         Storage.saveItem(lsKey, options, SettingsOptions.schema);
     }
 


### PR DESCRIPTION
This does two things:
- connects the music volume to the volume controls in the settings page
- adds a start/stop music button to the main menu

A slight challenge with the latter was that the music did not have the ability to stop. The most obvious solution is just to have a `isPlaying: boolean` that tracks whether or not music is playing, and have the measure generation cancel itself if it's not supposed to be playing. Unfortunately, this could run into a race condition that would fail to cancel the music, causing multiple music instances to run at the same time. The best way to implement this kind of thing would be to have the ability to cancel promises. Unfortunately, JS doesn't have async exceptions, masking, etc. Instead, we have to resort to a more naive implementation that does the initial solution, but waits until the music stops, blocking the button in between.

If you don't like the way this functions or appears, I'd be happy to change it; UI is not my specialty.

Resolves #67.