### PR TITLE
Add pause screen for changing settings/audio in game

### DIFF
--- a/src/UI/UI.ts
+++ b/src/UI/UI.ts
@@ -70,7 +70,7 @@ export namespace UI {
     // The callback may reference the button itself, as well as the mouse event.
     export function makeButton(
         text: string,
-        callback: (this: GlobalEventHandlers, button: HTMLButtonElement, ev: MouseEvent) => any,
+        callback: (button: HTMLButtonElement, ev: MouseEvent) => any,
         classes?: string[],
         buttonEnabled: "enabled" | "disabled" = "enabled"
     ): HTMLButtonElement {
@@ -83,9 +83,9 @@ export namespace UI {
         if (classes) {
             b.classList.add(...classes);
         }
-        b.onclick = function(this: GlobalEventHandlers, ev: MouseEvent) {
+        b.onclick = function(ev: MouseEvent) {
             ev.preventDefault();
-            callback.call(this, b, ev);
+            callback(b, ev);
         };
         if (containsEmoji(text)) {
             patchEmoji(b);

--- a/src/UI/menu/MainMenu.ts
+++ b/src/UI/menu/MainMenu.ts
@@ -16,23 +16,24 @@ export default class MainMenu implements Page {
         this.refresh();
     }
 
-    refresh(): void {
+    static makeAudioButton(menuPage: Page): HTMLButtonElement {
         const musicPlaying = MusicManager.isPlaying();
-        let musicButton;
         if (!musicPlaying) {
-            musicButton = UI.makeButton("enable audio", () => {
+            return UI.makeButton("enable audio", () => {
                 MusicManager.initialize();
-                this.refresh();
+                menuPage.refresh();
             });
         } else {
-            musicButton = UI.makeButton("disable audio", async (button: HTMLButtonElement) => {
+            return UI.makeButton("disable audio", async (button: HTMLButtonElement) => {
                 button.disabled = true;
                 button.innerText = "stopping audio...";
                 await MusicManager.stop();
-                this.refresh();
+                menuPage.refresh();
             });
         }
+    }
 
+    refresh(): void {
         UI.fillHTML(this.html, [
             UI.makeHeader("Aurora", 1),
             UI.makeDivContaining([
@@ -41,8 +42,8 @@ export default class MainMenu implements Page {
                     enableCheats(newGame);
                     GameWindow.show(new WorldScreen(newGame));
                 }),
-                musicButton,
-                UI.makeButton("change settings", () => GameWindow.show(new SettingsScreen())),
+                MainMenu.makeAudioButton(this),
+                UI.makeButton("change settings", () => GameWindow.show(new SettingsScreen(this))),
                 UI.makeButton("view credits", () => GameWindow.show(new CreditsScreen())),
             ], ["main-menu-options"]),
         ]);

--- a/src/UI/menu/PauseMenu.ts
+++ b/src/UI/menu/PauseMenu.ts
@@ -1,0 +1,33 @@
+import { UI } from "../UI.js";
+import { GameWindow, Page } from "../GameWindow.js";
+import MainMenu from "./MainMenu.js";
+import SettingsScreen from "./SettingsScreen.js";
+import Game from "../../Game.js";
+import WorldScreen from "../worldScreen/WorldScreen.js";
+
+export default class PauseMenu implements Page {
+    readonly html: HTMLElement;
+
+    constructor(private run: Game) {
+        this.html = UI.makeDiv(["main-menu"]);
+        this.refresh();
+    }
+
+    refresh(): void {
+        UI.fillHTML(this.html, [
+            UI.makeHeader("Game Paused", 2),
+            UI.makeDivContaining([
+                UI.makeButton("resume game", () => {
+                    GameWindow.show(new WorldScreen(this.run));
+                }),
+                MainMenu.makeAudioButton(this),
+                UI.makeButton("change settings", () => {
+                    GameWindow.show(new SettingsScreen(this));
+                }),
+                UI.makeButton("quit game", () => {
+                    GameWindow.show(new MainMenu());
+                }),
+            ], ["main-menu-options"]),
+        ]);
+    }
+}

--- a/src/UI/menu/SettingsScreen.ts
+++ b/src/UI/menu/SettingsScreen.ts
@@ -1,7 +1,6 @@
 import { Page } from "../GameWindow.js";
 import { UI } from "../UI.js";
 import { GameWindow } from "../GameWindow.js";
-import MainMenu from "../menu/MainMenu.js";
 
 import { Settings, SettingsOptions } from "../../persistence/Settings.js";
 
@@ -11,7 +10,9 @@ export default class SettingsScreen implements Page {
     // The current values of selected options
     options: SettingsOptions;
 
-    constructor() {
+    constructor(
+        private readonly backScreen: Page, // the page to return to
+    ) {
         this.html = UI.makeDiv();
         this.options = Settings.loadOptions();
         this.refresh();
@@ -58,7 +59,7 @@ export default class SettingsScreen implements Page {
                 UI.makeDivContaining([
                     UI.makeButton("Back", () => {
                         Settings.saveOptions(this.options);
-                        GameWindow.show(new MainMenu());
+                        GameWindow.show(this.backScreen);
                     }),
                 ]),
             ], ["settings"])

--- a/src/UI/worldScreen/WorldScreenHeader.ts
+++ b/src/UI/worldScreen/WorldScreenHeader.ts
@@ -1,7 +1,7 @@
 import Game from "../../Game.js";
 import { UI } from "../UI.js";
 import { GameWindow, Page } from "../GameWindow.js";
-import MainMenu from "../menu/MainMenu.js";
+import PauseMenu from "../menu/PauseMenu.js";
 import TransitionScreen from "../transitionScreen/TransitionScreen.js";
 import ProductionScreen from "../productionScreen/ProductionScreen.js";
 import ResearchScreen from "../researchScreen/ResearchScreen.js";
@@ -15,8 +15,8 @@ export default class WorldScreenHeader implements Page {
     }
 
     refresh(): void {
-        const quitButton = UI.makeButton("Quit Game", () => {
-            GameWindow.show(new MainMenu());
+        const quitButton = UI.makeButton("Pause Game", () => {
+            GameWindow.show(new PauseMenu(this.run));
         }, [], this.buttonState);
         const transitionButton = UI.makeButton("Next Turn", () => {
             const transitionScreen = new TransitionScreen(this.run);


### PR DESCRIPTION
Replaces the `Quit Game` button on the world screen with a pause menu that lets you change settings, enable/disable audio, quit the game, or resume. Previously, we could not change settings or enable/disable audio without quitting the game to the main menu.

Creation of the button to enable/disable music has been extracted to a static method in `MainMenu` so it can be reused in the pause menu. If there's a better place to put this, let me know.