### PR TITLE
Fix URL handling of PNG files in webpack

### DIFF
--- a/ci/webpack.config.js
+++ b/ci/webpack.config.js
@@ -23,11 +23,31 @@ module.exports = {
     rules: [
       {
         test: /\.css$/i,
-        use: [ MiniCssExtractPlugin.loader, "css-loader" ]
+        use: [
+          MiniCssExtractPlugin.loader,
+          "css-loader",
+        ]
       },
+      // URL handling for assets/**/*.png
+      {
+        test: /assets\/.*\.png$/i,
+        loader: "file-loader",
+        options: {
+          emitFile: false,
+          // Copy in path components relative to assets
+          regExp: /assets\/((?:.*?\/)*)[^\/]+\.png/,
+          name: "./assets/[1][name].[ext]",
+        },
+      },
+      // URL handling for fonts
       {
         test: /\.ttf$/i,
-        use: "url-loader?limit=100000&name=./assets/fonts/[name].[ext]",
+        loader: "url-loader",
+        options: {
+          limit: 100000,
+          name: "./assets/fonts/[name].[ext]",
+          emitFile: false,
+        },
       },
       {
         test: /\.html$/i,

--- a/stylesheets/menus.css
+++ b/stylesheets/menus.css
@@ -3,7 +3,7 @@
     top: 0;
     left: 0;
     background-color: black;
-    background-image: url(/assets/ui/planet.png);
+    background-image: url(../assets/ui/planet.png);
     background-color: black;
     background-size: contain;
     background-repeat: no-repeat;


### PR DESCRIPTION
Use a non-relative path for `planet.png`. This introduces a webpack error since it can't resolve `.png` files, so use `file-loader` to resolve the PNGs, substituting any path in `assets` to correct the URL. Furthermore, prevent redundant output of resolved assets to `dist` during minification.

This should fix the issue of `planet.png` 404'ing on GitHub pages; if we only correct the URL to the relative path `assets/ui/planet.png`, it will work correctly on GitHub pages but not on live-server.