### PR TITLE
Fix crash after quotes list is exhausted

### DIFF
--- a/src/util/Random.ts
+++ b/src/util/Random.ts
@@ -48,12 +48,13 @@ export namespace Random {
      * Modern Fisher-Yates shuffle of an array
      */
     export function shuffle<T>(arr: T[]): T[] {
-        for (let i = arr.length - 1; i > 0; i--) {
+        const newArr = [...arr];
+        for (let i = newArr.length - 1; i > 0; i--) {
             const j = Random.intBetween(0, i + 1);
-            const temp = arr[i];
-            arr[i] = arr[j];
-            arr[j] = temp;
+            const temp = newArr[i];
+            newArr[i] = newArr[j];
+            newArr[j] = temp;
         }
-        return arr;
+        return newArr;
     }
 }


### PR DESCRIPTION
Fixes consistent crash after 29 (I think) turns.

Since `shuffle` didn't actually allocate a new array, the quotes list was being emptied as the individual quotes were popped from the sample. When the sample was supposed to be refilled from the quotes list, both arrays eventually ended up empty, and they would loop forever as it counted `undefined` as a repeated quote.